### PR TITLE
fix(ai): read the assistant model from the account data

### DIFF
--- a/model/rag/chat.go
+++ b/model/rag/chat.go
@@ -359,6 +359,30 @@ func assistantForChat(inst *instance.Instance, chat *ChatConversation) (*chatAss
 	return &assistant, nil
 }
 
+func llmModel(acc *account.Account) string {
+	if model, _ := acc.Data["model"].(string); model != "" {
+		return model
+	}
+	if acc.Basic != nil {
+		return acc.Basic.Login
+	}
+	return ""
+}
+
+func llmAPIKey(basic *account.BasicInfo) string {
+	if basic == nil {
+		return ""
+	}
+	if basic.EncryptedCredentials == "" {
+		return basic.Password
+	}
+	_, apiKey, err := account.DecryptCredentials(basic.EncryptedCredentials)
+	if err != nil {
+		return basic.Password
+	}
+	return apiKey
+}
+
 // buildLLMOverride returns the `metadata.llm_override` map forwarded to
 // OpenRAG when the conversation is bound to an assistant that uses an
 // external provider (OpenAI, Mistral, …). It returns nil to leave the
@@ -378,16 +402,7 @@ func buildLLMOverride(inst *instance.Instance, assistant *chatAssistant) map[str
 	if err := couchdb.GetDoc(inst, consts.Accounts, provider.ID, &acc); err != nil {
 		return nil
 	}
-	// The account's "login" field stores the LLM model name, e.g. "Mistral-Small-3.2-24B-Instruct-2506"
-	// While "password" stores the API key
-	var model, apiKey string
-	if acc.Basic != nil {
-		if acc.Basic.EncryptedCredentials != "" {
-			model, apiKey, _ = account.DecryptCredentials(acc.Basic.EncryptedCredentials)
-		} else {
-			model, apiKey = acc.Basic.Login, acc.Basic.Password
-		}
-	}
+	model, apiKey := llmModel(&acc), llmAPIKey(acc.Basic)
 	override := map[string]interface{}{}
 	if model != "" {
 		override["model"] = model

--- a/model/rag/chat_test.go
+++ b/model/rag/chat_test.go
@@ -4,9 +4,92 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cozy/cozy-stack/model/account"
+	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLLMModel(t *testing.T) {
+	t.Run("no data and no auth", func(t *testing.T) {
+		assert.Empty(t, llmModel(&account.Account{}))
+	})
+
+	t.Run("model comes from the account data", func(t *testing.T) {
+		acc := &account.Account{
+			Data: map[string]interface{}{"model": "gemini-3-pro"},
+		}
+		assert.Equal(t, "gemini-3-pro", llmModel(acc))
+	})
+
+	t.Run("data wins over a legacy login", func(t *testing.T) {
+		acc := &account.Account{
+			Data:  map[string]interface{}{"model": "gemini-3-pro"},
+			Basic: &account.BasicInfo{Login: "gemini-2.5-flash"},
+		}
+		assert.Equal(t, "gemini-3-pro", llmModel(acc))
+	})
+
+	t.Run("falls back to the login on accounts written before the move", func(t *testing.T) {
+		acc := &account.Account{
+			Basic: &account.BasicInfo{Login: "gemini-2.5-flash"},
+		}
+		assert.Equal(t, "gemini-2.5-flash", llmModel(acc))
+	})
+
+	t.Run("a stale encrypted model is never used", func(t *testing.T) {
+		// Editing the model without retyping the API key left the encrypted
+		// blob on the previous model. It must not resurrect it.
+		config.UseTestFile(t)
+		encrypted, err := account.EncryptCredentials("gemini-2.5-flash", "s3cret")
+		require.NoError(t, err)
+
+		acc := &account.Account{
+			Data:  map[string]interface{}{"model": "gemini-3-pro"},
+			Basic: &account.BasicInfo{EncryptedCredentials: encrypted},
+		}
+		assert.Equal(t, "gemini-3-pro", llmModel(acc))
+	})
+
+	t.Run("no model rather than a stale one when data is empty", func(t *testing.T) {
+		config.UseTestFile(t)
+		encrypted, err := account.EncryptCredentials("gemini-2.5-flash", "s3cret")
+		require.NoError(t, err)
+
+		acc := &account.Account{
+			Basic: &account.BasicInfo{EncryptedCredentials: encrypted},
+		}
+		assert.Empty(t, llmModel(acc))
+	})
+}
+
+func TestLLMAPIKey(t *testing.T) {
+	config.UseTestFile(t)
+
+	t.Run("no basic auth", func(t *testing.T) {
+		assert.Empty(t, llmAPIKey(nil))
+	})
+
+	t.Run("plain password when nothing is encrypted", func(t *testing.T) {
+		assert.Equal(t, "s3cret", llmAPIKey(&account.BasicInfo{Password: "s3cret"}))
+	})
+
+	t.Run("api key comes from the encrypted credentials", func(t *testing.T) {
+		encrypted, err := account.EncryptCredentials("", "s3cret")
+		require.NoError(t, err)
+
+		assert.Equal(t, "s3cret", llmAPIKey(&account.BasicInfo{
+			EncryptedCredentials: encrypted,
+		}))
+	})
+
+	t.Run("undecipherable credentials fall back to the plain password", func(t *testing.T) {
+		assert.Equal(t, "s3cret", llmAPIKey(&account.BasicInfo{
+			Password:             "s3cret",
+			EncryptedCredentials: "not-a-valid-blob",
+		}))
+	})
+}
 
 func TestForeachSSE(t *testing.T) {
 	t.Run("normal events are passed to callback", func(t *testing.T) {


### PR DESCRIPTION
## Problem

Changing an AI assistant's model has no effect unless the API key is retyped at the same time: the conversation keeps running on the model the assistant was created with.

The provider account stores the model in `auth.login` and the API key in `auth.password`, and the stack bundles the two into `auth.credentials_encrypted` (`encryptMap`, `model/account/credentials.go`). That blob is only rebuilt when a `password` is present in the incoming document, so editing only the model leaves it encrypting the *previous* model — and `buildLLMOverride` read the blob in preference to the plain fields.

The model therefore exists in two places that drift apart, and the stale one won.

## Fix

Rather than picking the fresher of the two copies, stop duplicating the model.

The model is configuration, not a credential, so it moves to `data.model`, next to the `data.baseUrl` that was already there — out of reach of the encryptor, which only ever touches `auth`. The two concerns are split into `llmModel` and `llmAPIKey`:

| | before | after |
|---|---|---|
| model | `auth.login`, duplicated into the encrypted blob | `data.model` |
| API key | `auth.password` → encrypted blob | unchanged |
| base URL | `data.baseUrl` | unchanged |

`auth` now holds what must be encrypted, `data` holds the rest, and the resulting triplet maps one-to-one onto OpenRAG's `llm_override` = `{model, api_key, base_url}`.

The encrypted blob is deliberately never consulted for the model: its copy is precisely the one that goes stale, and resurrecting it would turn a missing field into a silently wrong value.

## Impact

**No migration required.** Accounts written before the move still carry the model in `auth.login`, which is never encrypted and therefore always up to date, so `llmModel` falls back to it. Every existing assistant is fixed as soon as this is deployed, and the stack can ship independently of the client.

The fallback is marked as transitional: it can be dropped once cozy-client writes `data.model` and existing accounts have been rewritten.

## Follow-up on the client side

cozy-client must write `data.model` and stop writing `auth.login`. Note the ordering constraint: an account's display label is derived from `auth[account.identifier]`, falling back to `auth.login` (cozy-harvest-lib `getLabel`, cozy-doctypes `Account.getAccountName`). Once `auth.login` is gone, that falls through to `account._id`, so the client change that sets `identifier: 'accountName'` and `auth.accountName` must land first.

That naming is a separate symptom of the same root cause — with the model sitting in `auth.login`, `ComputeName` labelled these accounts `gemini-2.5-flash` instead of `Google` — and is handled in its own client-side PR.

## Tests

`TestLLMModel` and `TestLLMAPIKey` cover the data/login precedence, the legacy fallback, the encrypted-key paths, and one case that explicitly locks in that a stale encrypted model is never resurrected.
