### PR TITLE
feat(rabbitmq): store the matrix id received on user.created

### DIFF
--- a/docs/rabbitmq.md
+++ b/docs/rabbitmq.md
@@ -305,9 +305,15 @@ Example payload for `user.created`:
   "workplaceFqdn": "alice.example.twake.app",
   "organizationId": "org-uuid-123",
   "organizationDomain": "example.com",
-  "canUpgrade": false
+  "canUpgrade": false,
+  "matrixId": "@alice:example.twake.app"
 }
 ```
+
+`matrixId` is optional. When it is present and well-formed, it is saved as
+`matrix_id` in the instance settings document and sent to the common settings
+API as the account's Matrix identity; otherwise the Matrix ID is derived from
+the email local part and the instance domain.
 
 
 Example payload for `b2b/domain.user.deleted`:

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -734,6 +734,15 @@ This attribute will only be present if a manager is associated with the
 instance and the instance was created on behalf of a partner with a defined
 legal notice.
 
+##### Note about `matrix_id`
+
+This attribute is only present when the `user.created` RabbitMQ message carried
+a `matrixId`. It is read-only: like `email`, it is restored from the stored
+document on `PUT /settings/instance`, so a client can neither change it nor
+erase it with a partial update. When it is absent, the Matrix ID sent to the
+common settings API is derived from the email local part and the instance
+domain.
+
 ### POST /settings/instance/deletion
 
 The settings application can use this route if the user wants to delete their

--- a/model/settings/common/common.go
+++ b/model/settings/common/common.go
@@ -127,6 +127,9 @@ func UpdateCommonSettings(inst *instance.Instance, settings *couchdb.JSONDoc) (b
 		if email, ok := settings.M["email"].(string); ok {
 			addDiff("email", remote.Payload.Email, email)
 		}
+		if matrixID, _ := settings.M["matrix_id"].(string); matrixID != "" {
+			addDiff("matrix_id", remote.Payload.MatrixID, matrixID)
+		}
 
 		log.Warnf("common settings out of sync: local=%d remote=%d", inst.CommonSettingsVersion, remote.Version)
 		if len(diffs) > 0 {
@@ -307,7 +310,9 @@ func buildRequest(inst *instance.Instance, settings *couchdb.JSONDoc) UserSettin
 	if phone, ok := settings.M["phone"].(string); ok {
 		request.Payload.Phone = phone
 	}
-	if len(parts) > 1 {
+	if matrixID, _ := settings.M["matrix_id"].(string); IsMatrixID(matrixID) {
+		request.Payload.MatrixID = matrixID
+	} else if len(parts) > 1 {
 		// The Matrix localpart comes from the email local part, which preserves
 		// dots and can differ from the domain slug. Fall back to the slug when
 		// no email is available. The homeserver part stays domain-derived.
@@ -321,6 +326,22 @@ func buildRequest(inst *instance.Instance, settings *couchdb.JSONDoc) UserSettin
 	}
 
 	return request
+}
+
+// maxMatrixIDLength is the maximum length of a Matrix user ID.
+const maxMatrixIDLength = 255
+
+// IsMatrixID reports whether id has the `@localpart:server` shape. A stored
+// value that fails the check is ignored in favour of the derived one.
+func IsMatrixID(id string) bool {
+	if len(id) > maxMatrixIDLength || !strings.HasPrefix(id, "@") {
+		return false
+	}
+	if strings.ContainsAny(id, " \t\r\n") {
+		return false
+	}
+	localpart, server, found := strings.Cut(id[1:], ":")
+	return found && localpart != "" && server != ""
 }
 
 func addAvatarURL(inst *instance.Instance, request *UserSettingsRequest, version int) {

--- a/model/settings/common/common_test.go
+++ b/model/settings/common/common_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/cozy/cozy-stack/model/instance"
@@ -10,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildRequest_MatrixIDFromEmail(t *testing.T) {
+func TestBuildRequest_MatrixID(t *testing.T) {
 	inst := &instance.Instance{Domain: "alicewonderland.stg.lin-saas.com"}
 
 	t.Run("email localpart preserves dots and drives the matrix id", func(t *testing.T) {
@@ -43,6 +44,68 @@ func TestBuildRequest_MatrixIDFromEmail(t *testing.T) {
 		req := buildRequest(local, settings)
 		require.Empty(t, req.Payload.MatrixID)
 	})
+
+	t.Run("a stored matrix id wins over the email and is sent as is", func(t *testing.T) {
+		settings := &couchdb.JSONDoc{M: map[string]interface{}{
+			"matrix_id": "@al.ice:stg.lin-saas.com",
+			"email":     "alicewonderland@stg.lin-saas.com",
+		}}
+		req := buildRequest(inst, settings)
+		require.Equal(t, "@al.ice:stg.lin-saas.com", req.Payload.MatrixID)
+	})
+
+	t.Run("an empty stored matrix id falls back to the email", func(t *testing.T) {
+		settings := &couchdb.JSONDoc{M: map[string]interface{}{
+			"matrix_id": "",
+			"email":     "al.ice@stg.lin-saas.com",
+		}}
+		req := buildRequest(inst, settings)
+		require.Equal(t, "@al.ice:stg.lin-saas.com", req.Payload.MatrixID)
+	})
+
+	t.Run("a non-string stored matrix id falls back to the email", func(t *testing.T) {
+		settings := &couchdb.JSONDoc{M: map[string]interface{}{
+			"matrix_id": 42,
+			"email":     "al.ice@stg.lin-saas.com",
+		}}
+		req := buildRequest(inst, settings)
+		require.Equal(t, "@al.ice:stg.lin-saas.com", req.Payload.MatrixID)
+	})
+
+	t.Run("a malformed stored matrix id falls back to the email", func(t *testing.T) {
+		settings := &couchdb.JSONDoc{M: map[string]interface{}{
+			"matrix_id": "not-a-matrix-id",
+			"email":     "al.ice@stg.lin-saas.com",
+		}}
+		req := buildRequest(inst, settings)
+		require.Equal(t, "@al.ice:stg.lin-saas.com", req.Payload.MatrixID)
+	})
+}
+
+func TestIsMatrixID(t *testing.T) {
+	valid := []string{
+		"@alice:example.org",
+		"@al.ice:stg.example.org",
+		"@alice:example.org:8448",
+	}
+	for _, id := range valid {
+		require.True(t, IsMatrixID(id), id)
+	}
+
+	invalid := []string{
+		"",
+		"alice:example.org",          // no leading @
+		"@alice",                     // no server part
+		"@:example.org",              // empty localpart
+		"@alice:",                    // empty server
+		"alice@example.org",          // an email, not a matrix id
+		"@alice example:example.org", // inner whitespace
+		"@alice:example.org\n",       // trailing newline
+		"@" + strings.Repeat("a", 300) + ":example.org", // over the length cap
+	}
+	for _, id := range invalid {
+		require.False(t, IsMatrixID(id), id)
+	}
 }
 
 func TestUpdateCommonSettings_VersionMismatchReturnsTypedError(t *testing.T) {

--- a/pkg/rabbitmq/handlers.go
+++ b/pkg/rabbitmq/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/model/orgdirectory"
+	"github.com/cozy/cozy-stack/model/settings/common"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/pkg/logger"
@@ -140,6 +141,7 @@ type UserCreatedMessage struct {
 	WorkplaceFqdn      string `json:"workplaceFqdn"` // The fully qualified workplace domain
 	OrganizationID     string `json:"organizationId,omitempty"`
 	OrganizationDomain string `json:"organizationDomain,omitempty"`
+	MatrixID           string `json:"matrixId,omitempty"` // Stored as received, it takes precedence over the ID derived from the email
 }
 
 // Handle processes a user created message.
@@ -154,11 +156,12 @@ func (h *UserCreatedHandler) Handle(ctx context.Context, d amqp.Delivery) error 
 	log.Debugf("user.created: successfully unmarshaled message for TwakeID: %s", msg.TwakeID)
 
 	// Log incoming message with masked sensitive data
-	log.Infof("user.created: processing message - TwakeID: %s, Domain: %s, Mobile: %s, InternalEmail: %s, Iterations: %d, Hash: %s, PublicKey: %s, PrivateKey: %s, Key: %s, Timestamp: %d",
+	log.Infof("user.created: processing message - TwakeID: %s, Domain: %s, Mobile: %s, InternalEmail: %s, MatrixID: %s, Iterations: %d, Hash: %s, PublicKey: %s, PrivateKey: %s, Key: %s, Timestamp: %d",
 		msg.TwakeID,
 		msg.Domain,
 		msg.Mobile,
 		msg.InternalEmail,
+		msg.MatrixID,
 		msg.Iterations,
 		maskSensitiveData(msg.Hash),
 		maskSensitiveData(msg.PublicKey),
@@ -225,6 +228,12 @@ func (h *UserCreatedHandler) Handle(ctx context.Context, d amqp.Delivery) error 
 		log.Infof("user.created: successfully updated passphrase for instance: %s (PasswordDefined: %v)", inst.Domain, inst.PasswordDefined)
 	}
 
+	if matrixID := strings.TrimSpace(msg.MatrixID); matrixID != "" {
+		if err := storeMatrixID(inst, matrixID); err != nil {
+			return err
+		}
+	}
+
 	if strings.TrimSpace(msg.OrganizationID) != "" || strings.TrimSpace(msg.OrganizationDomain) != "" {
 		scope, err := orgdirectory.ResolveOrganizationInstances(msg.OrganizationID, msg.OrganizationDomain)
 		if err != nil {
@@ -244,6 +253,34 @@ func (h *UserCreatedHandler) Handle(ctx context.Context, d amqp.Delivery) error 
 		}
 	}
 
+	return nil
+}
+
+// storeMatrixID saves the Matrix ID carried by a user.created message, which
+// buildRequest then forwards in place of the one derived from the email. A
+// malformed ID is dropped rather than retried, and an unchanged one is patched
+// anyway so a redelivery retries the common settings push.
+func storeMatrixID(inst *instance.Instance, matrixID string) error {
+	if !common.IsMatrixID(matrixID) {
+		log.Warnf("user.created: ignoring malformed matrix id %q for instance: %s", matrixID, inst.Domain)
+		return nil
+	}
+
+	settings, err := inst.SettingsDocument()
+	if err != nil {
+		return fmt.Errorf("user.created: get settings document: %w", err)
+	}
+
+	settings.M["matrix_id"] = matrixID
+
+	if err := lifecycle.Patch(inst, &lifecycle.Options{
+		SettingsObj:  settings,
+		FromCloudery: true, // XXX: the Cloudery has no matrix_id field
+	}); err != nil {
+		return fmt.Errorf("user.created: update matrix id: %w", err)
+	}
+
+	log.Infof("user.created: stored matrix id for instance: %s", inst.Domain)
 	return nil
 }
 

--- a/pkg/rabbitmq/handlers_test.go
+++ b/pkg/rabbitmq/handlers_test.go
@@ -1,0 +1,97 @@
+package rabbitmq_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/rabbitmq"
+	"github.com/cozy/cozy-stack/tests/testutils"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUserCreatedHandlerStoresMatrixID checks that the Matrix ID a user.created
+// message carries lands in the instance settings document, which is where
+// buildRequest reads it from.
+func TestUserCreatedHandlerStoresMatrixID(t *testing.T) {
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+
+	// A forced OIDC context lets a message through without a passphrase hash,
+	// which is not what this test is about.
+	contextName := "matrix-id-test"
+	conf := config.GetConfig()
+	conf.Authentication = map[string]interface{}{
+		contextName: map[string]interface{}{"disable_password_authentication": true},
+	}
+
+	newInstance := func(t *testing.T) string {
+		t.Helper()
+		domain := fmt.Sprintf("matrix-id-%d.example", time.Now().UnixNano())
+		inst, err := lifecycle.Create(&lifecycle.Options{
+			Domain:      domain,
+			Email:       "alice@example.org",
+			ContextName: contextName,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = lifecycle.Destroy(domain) })
+		return inst.Domain
+	}
+
+	storedMatrixID := func(t *testing.T, domain string) string {
+		t.Helper()
+		inst, err := lifecycle.GetInstance(domain)
+		require.NoError(t, err)
+		settings, err := inst.SettingsDocument()
+		require.NoError(t, err)
+		id, _ := settings.M["matrix_id"].(string)
+		return id
+	}
+
+	handle := func(t *testing.T, domain, matrixID string) error {
+		t.Helper()
+		body, err := json.Marshal(rabbitmq.UserCreatedMessage{
+			TwakeID:       "alice",
+			WorkplaceFqdn: domain,
+			MatrixID:      matrixID,
+		})
+		require.NoError(t, err)
+
+		return rabbitmq.NewUserCreatedHandler().
+			Handle(context.Background(), amqp.Delivery{Body: body})
+	}
+
+	t.Run("stores the matrix id it receives", func(t *testing.T) {
+		domain := newInstance(t)
+
+		require.NoError(t, handle(t, domain, "@al.ice:example.org"))
+		require.Equal(t, "@al.ice:example.org", storedMatrixID(t, domain))
+	})
+
+	t.Run("a redelivery leaves the same value in place", func(t *testing.T) {
+		domain := newInstance(t)
+
+		require.NoError(t, handle(t, domain, "@al.ice:example.org"))
+		require.NoError(t, handle(t, domain, "@al.ice:example.org"))
+		require.Equal(t, "@al.ice:example.org", storedMatrixID(t, domain))
+	})
+
+	t.Run("a malformed matrix id is dropped, not stored", func(t *testing.T) {
+		domain := newInstance(t)
+
+		require.NoError(t, handle(t, domain, "al.ice@example.org"))
+		require.Empty(t, storedMatrixID(t, domain))
+	})
+
+	t.Run("a message without a matrix id stores nothing", func(t *testing.T) {
+		domain := newInstance(t)
+
+		require.NoError(t, handle(t, domain, ""))
+		require.Empty(t, storedMatrixID(t, domain))
+	})
+}

--- a/web/settings/instance.go
+++ b/web/settings/instance.go
@@ -135,7 +135,9 @@ func (h *HTTPHandler) updateInstance(c echo.Context) error {
 		// replaced wholesale on patch, so the stored value is put back rather than
 		// the incoming one merely dropped; a read failure aborts the request
 		// instead of risking a wipe.
-		guarded := []string{"email", "pending_email"}
+		// matrix_id is guarded for the same reason: it is the account's Matrix
+		// identity downstream, so a client must not claim another one nor drop it.
+		guarded := []string{"email", "pending_email", "matrix_id"}
 		if inst.HasSignup() {
 			guarded = append(guarded, "phone", "recovery_email")
 		}

--- a/web/settings/settings_test.go
+++ b/web/settings/settings_test.go
@@ -1063,6 +1063,77 @@ func TestSettings(t *testing.T) {
 		attrs.HasValue("tz", "Pacific/Auckland")
 	})
 
+	t.Run("UpdateInstanceGuardsMatrixID", func(t *testing.T) {
+		// matrix_id is written by the user.created RabbitMQ handler and is sent
+		// to the common settings API as the account's Matrix identity, so a
+		// client can neither claim another one nor erase it with a partial
+		// update.
+		stored, err := testInstance.SettingsDocument()
+		require.NoError(t, err)
+		stored.M["matrix_id"] = "@alice:example.com"
+		require.NoError(t, couchdb.UpdateDoc(testInstance, stored))
+		t.Cleanup(func() {
+			doc, err := testInstance.SettingsDocument()
+			if err != nil {
+				return
+			}
+			delete(doc.M, "matrix_id")
+			_ = couchdb.UpdateDoc(testInstance, doc)
+		})
+
+		doc, err := testInstance.SettingsDocument()
+		require.NoError(t, err)
+		e := testutils.CreateTestClient(t, tsURL)
+		obj := e.PUT("/settings/instance").
+			WithCookie(sessCookie, "connected").
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithHeader("Authorization", "Bearer "+token).
+			WithBytes([]byte(fmt.Sprintf(`{
+        "data": {
+          "type": "io.cozy.settings",
+          "id": "io.cozy.settings.instance",
+          "meta": {"rev": "%s"},
+          "attributes": {
+            "matrix_id": "@attacker:evil.example",
+            "tz": "Europe/Lisbon"
+          }
+        }
+      }`, doc.Rev()))).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+
+		attrs := obj.Value("data").Object().Value("attributes").Object()
+		attrs.HasValue("matrix_id", "@alice:example.com") // guarded: not changed
+		attrs.HasValue("tz", "Europe/Lisbon")
+
+		// A partial update that leaves matrix_id out must not erase it, since
+		// the settings doc is replaced wholesale on patch.
+		doc, err = testInstance.SettingsDocument()
+		require.NoError(t, err)
+		e.PUT("/settings/instance").
+			WithCookie(sessCookie, "connected").
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithHeader("Accept", "application/vnd.api+json").
+			WithHeader("Authorization", "Bearer "+token).
+			WithBytes([]byte(fmt.Sprintf(`{
+        "data": {
+          "type": "io.cozy.settings",
+          "id": "io.cozy.settings.instance",
+          "meta": {"rev": "%s"},
+          "attributes": {
+            "tz": "Europe/Madrid"
+          }
+        }
+      }`, doc.Rev()))).
+			Expect().Status(200)
+
+		after, err := testInstance.SettingsDocument()
+		require.NoError(t, err)
+		assert.Equal(t, "@alice:example.com", after.M["matrix_id"])
+	})
+
 	t.Run("PostEmailBlockedWhenSignupEnabled", func(t *testing.T) {
 		// The dedicated email-change flow is also disabled on signup-managed
 		// contexts.


### PR DESCRIPTION
## Problem

The Matrix ID sent to the common settings service is derived from the email local part, which is not always the address of the account.

## Solution

Store the `matrixId` that `user.created` now carries, and send that. Instances without one keep the existing derivation.

Closes #4887
