### PR TITLE
Allow dataproxy to be framed inside an intent

### DIFF
--- a/tests/testutils/test_utils.go
+++ b/tests/testutils/test_utils.go
@@ -397,6 +397,48 @@ func (c *TestSetup) InstallMiniApp() (string, error) {
 	return slug, err
 }
 
+func (c *TestSetup) InstallMiniDataProxy(t *testing.T) error {
+	slug := consts.DataProxySlug
+	instance := c.GetTestInstance()
+
+	version := "1.0.0"
+	manifest := &couchdb.JSONDoc{
+		Type: consts.Apps,
+		M: map[string]interface{}{
+			"_id":   consts.Apps + "/" + slug,
+			"name":  "DataProxy",
+			"slug":  slug,
+			"state": apps.Ready,
+			"routes": apps.Routes{
+				"/": apps.Route{
+					Folder: "/",
+					Index:  "index.html",
+					Public: true,
+				},
+			},
+			"permissions": permission.Set{},
+			"version":     version,
+		},
+	}
+
+	if err := couchdb.CreateNamedDoc(instance, manifest); err != nil {
+		return err
+	}
+	t.Cleanup(func() {
+		_ = permission.DestroyWebapp(instance, slug)
+		_ = couchdb.DeleteDoc(instance, manifest)
+	})
+	if _, err := permission.CreateWebappSet(instance, slug, permission.Set{}, version); err != nil {
+		return err
+	}
+
+	appdir := path.Join(vfs.WebappsDirName, slug, version)
+	if _, err := vfs.MkdirAll(instance.VFS(), appdir); err != nil {
+		return err
+	}
+	return createFile(instance, appdir, "index.html", "this is the dataproxy index")
+}
+
 func (c *TestSetup) InstallMiniKonnector() (string, error) {
 	slug := "mini"
 	instance := c.GetTestInstance()

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -333,14 +333,7 @@ func TestApps(t *testing.T) {
 		require.NoError(t, couchdb.CreateNamedDoc(testInstance, clientURLApp))
 		t.Cleanup(func() { _ = couchdb.DeleteDoc(testInstance, clientURLApp) })
 
-		testInstance.FeatureFlags = map[string]interface{}{
-			"clienturl_csp_flag": "https://external.example.com",
-		}
-		require.NoError(t, instance.Update(testInstance))
-		t.Cleanup(func() {
-			testInstance.FeatureFlags = nil
-			_ = instance.Update(testInstance)
-		})
+		testutils.WithFlag(t, testInstance, "clienturl_csp_flag", "https://external.example.com")
 
 		intent := &intent.Intent{
 			Action: "PICK",

--- a/web/apps/apps_test.go
+++ b/web/apps/apps_test.go
@@ -360,6 +360,53 @@ func TestApps(t *testing.T) {
 		csp.Contains("frame-ancestors 'self' https://external.example.com https://clienturl-app.cozywithapps.example.net;")
 	})
 
+	t.Run("ServeDataProxyWithIntentAllowsContainerAppsFrame", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		require.NoError(t, setup.InstallMiniDataProxy(t))
+		containerApp := &couchdb.JSONDoc{
+			Type: consts.Apps,
+			M: map[string]interface{}{
+				"_id":             consts.Apps + "/container-app",
+				"name":            "ContainerApp",
+				"slug":            "container-app",
+				"source":          "git://github.com/cozy/containerapp.git",
+				"state":           apps.Ready,
+				"client_url_flag": "container_csp_flag",
+				"routes":          apps.Routes{},
+				"permissions":     permission.Set{},
+				"version":         "1.0.0",
+			},
+		}
+		require.NoError(t, couchdb.CreateNamedDoc(testInstance, containerApp))
+		t.Cleanup(func() { _ = couchdb.DeleteDoc(testInstance, containerApp) })
+
+		testutils.WithFlag(t, testInstance, "container_csp_flag", "https://external.example.com")
+
+		intent := &intent.Intent{
+			Action:   "PICK",
+			Type:     "io.cozy.foos",
+			Client:   "io.cozy.apps/container-app",
+			Services: []intent.Service{{Slug: consts.DataProxySlug, Href: "/"}},
+		}
+		require.NoError(t, intent.Save(testInstance))
+
+		csp := e.GET("/").
+			WithHost(consts.DataProxySlug + "." + testInstance.Domain).
+			WithQueryString("intent=" + intent.ID()).
+			Expect().Status(200).
+			Header(echo.HeaderContentSecurityPolicy)
+
+		csp.Contains("frame-ancestors 'self'")
+		// Cozy root (login page rule)
+		csp.Contains("https://cozywithapps.example.net/")
+		// All container apps and their external clients
+		csp.Contains("https://external.example.com")
+		csp.Contains("https://container-app.cozywithapps.example.net")
+		// Apps without a client_url_flag are not added
+		csp.NotContains("https://mini.cozywithapps.example.net")
+	})
+
 	t.Run("NoScriptTagBreakoutIntentData", func(t *testing.T) {
 		e := testutils.CreateTestClient(t, ts.URL)
 

--- a/web/apps/serve.go
+++ b/web/apps/serve.go
@@ -149,6 +149,33 @@ func handleIntent(c echo.Context, i *instance.Instance, slug, intentID string) *
 	return intent
 }
 
+// allowContainerAppsFrame adds to frame-ancestors the cozy subdomain and the
+// client URL (via its client_url_flag feature flag) of every installed app
+// that declares one. Dataproxy can be nested several iframes deep in an
+// intent flow (e.g. a container app framing its external client, which frames
+// the intent client, which frames dataproxy), and frame-ancestors must list
+// every ancestor in the chain.
+func allowContainerAppsFrame(c echo.Context, i *instance.Instance) {
+	if config.GetConfig().CSPDisabled {
+		return
+	}
+	manifests, _, err := app.ListWebappsWithPagination(i, 0, "")
+	if err != nil {
+		return
+	}
+	for _, manifest := range manifests {
+		if manifest.ClientURLFlag() == "" {
+			continue
+		}
+		from := app.ResolveClientURL(i, manifest.Slug())
+		defaultFrom := app.DefaultClientURL(i, manifest.Slug())
+		middlewares.AppendCSPRule(c, "frame-ancestors", from)
+		if defaultFrom != from {
+			middlewares.AppendCSPRule(c, "frame-ancestors", defaultFrom)
+		}
+	}
+}
+
 // ServeAppFile will serve the requested file using the specified application
 // manifest and appfs.FileServer context.
 //
@@ -271,6 +298,10 @@ func ServeAppFile(c echo.Context, i *instance.Instance, fs appfs.FileServer, web
 	var intentDoc *intent.Intent
 	if intentID := c.QueryParam("intent"); intentID != "" {
 		intentDoc = handleIntent(c, i, slug, intentID)
+
+		if intentDoc != nil && slug == consts.DataProxySlug {
+			allowContainerAppsFrame(c, i)
+		}
 	}
 
 	if route.Public && slug == consts.DataProxySlug {


### PR DESCRIPTION
To enable search and recent tabs in the File Picker, we need to add the dataproxy in the File Picker. So we need to set up the appropriate frame-ancestors CSP for the dataproxy.

However, the dataproxy does not fit with the current CSP when using an intent with external apps (like when tmail load the File Picker).

In https://github.com/linagora/cozy-stack/pull/4824, I implemented a first solution for external apps like tmail. When an intent is created by an app associated to an external app, it adds both URL in CSP (cozy container url + external app url).

But as we can see in the schema below the dataproxy intent is not created by the tmail container or the tmail app. It is created by the File Picker so by tdrive. So this first solution does not work (it only adds tdrive in dataproxy frame-ancestors). Moreover the dataproxy intent can not know if it has been created by a usual cozy apps (eg tdrive) or by an app associated to an external app (eg tmail).

<img width="500" alt="Screenshot 2026-08-25 at 10 07 22" src="https://github.com/user-attachments/assets/9a473fd6-e495-4904-8f4e-6aebdf12a208" />

That's why here I propose to add in CSP _only for the dataproxy_ **all apps that have an external app attached**. So for example, the dataproxy will allows to be framed by calendar container & calendar app & mail container & mail app when it is loaded in an intent. We open "more what we need" but I do not see other solution and the blast radius stay controlled because we only allow app that can open the dataproxy anyway.

Tell me what you think. I am open to other solution.