### PR TITLE
feat: Use effective access in shared drive files routes

### DIFF
--- a/docs/shared-drives.md
+++ b/docs/shared-drives.md
@@ -358,6 +358,21 @@ member:
   write on the destination folder;
 - `POST /sharings/drives/:id/:file-id/copy` requires effective read on the
   source file and effective write on the destination folder;
+- open routes (`GET /sharings/drives/:id/notes/:file-id/open`, `GET
+  /sharings/drives/:id/office/:file-id/open`, `GET
+  /sharings/drives/:id/editor/:file-id/open`) require effective read on the
+  target file. The opening is **forced read-only** when the member lacks
+  effective write on the target: the share-interact token carries ALL verbs
+  (including write), so the read-only restriction is enforced at the
+  application layer by rewriting the `ReadOnly` query parameter to `true`
+  before delegating to the note/office/editor handler. A member with
+  effective write access opens the file in read-write mode (unless they
+  explicitly pass `ReadOnly=true`); in that case the returned sharecode is
+  minted from the nearest sharing scope that grants the effective write (e.g.
+  a nested drive), never from the drive whose route was called when that
+  drive only grants read: the share-interact permission set covers the whole
+  drive, and a code scoped beyond the member's effective write would let them
+  write files they cannot write;
 - trash routes (`POST`/`DELETE /sharings/drives/:id/trash/:file-id`) target
   files outside every sharing scope: restore and destroy require effective
   write on the folder the file would be restored to (or on its first
@@ -1121,12 +1136,16 @@ drives return `422 Unprocessable Entity`.
 Return the parameters to build the URL where the note can be opened.
 Identical to [`GET /notes/:file-id/open`](notes.md#get-notesidopen).
 
+Drive tokens (share-interact) are checked against the member's effective read access on the target; a target outside every sharing scope of the caller is answered `404 Not Found`. The opening is forced read-only (the sharecode resolves to a `share-preview` permission) when the member lacks effective write access on the target. Otherwise the sharecode is minted from the nearest sharing scope that grants the effective write.
+
 ## Office
 
 ### GET /sharings/drives/:id/office/:file-id/open
 
 Returns the parameters to open an office document. Identical to
 [`GET /office/:file-id/open`](office.md#get-officeidopen).
+
+Drive tokens are checked and the opening forced read-only the same way as the notes open route.
 
 ## Editors
 
@@ -1136,9 +1155,7 @@ Return the parameters to open a file from a shared drive with an editor.
 Identical to [`GET /editor/:file-id/open`](files.md#get-editorfile-idopen), but
 scoped to the shared drive.
 
-Recipients are resolved through the shared-drive owner instance, so the returned
-`instance`, `file_id`, and `sharecode` are the values to use for opening the
-file on that owner instance.
+Drive tokens are checked and the opening forced read-only the same way as the notes open route.
 
 ## Shortcuts
 

--- a/docs/shared-drives.md
+++ b/docs/shared-drives.md
@@ -362,7 +362,14 @@ member:
   files outside every sharing scope: restore and destroy require effective
   write on the folder the file would be restored to (or on its first
   existing ancestor when the original folder hierarchy was deleted, as the
-  restore recreates it there).
+  restore recreates it there);
+- temporary download links (`POST /sharings/drives/:id/downloads` and `POST
+  /sharings/drives/:id/archive`) require effective read on every target
+  before minting the link. A target outside every sharing scope of the
+  caller is answered `404 Not Found`. The resulting `:secret` URL is not
+  authenticated (by design, so browsers can use it directly), so the link
+  should be treated as a capability: anyone holding it can download the
+  prepared content until it expires.
 
 `GET /sharings/drives/:id/_changes` is not resolved per target: it returns
 the changes of the whole drive to every member. In the additive access mode,
@@ -403,6 +410,8 @@ Two-step download of a single file: creates a short-lived secret link (valid 10 
 
 Identical call to [`POST /files/downloads`](files.md#post-filesdownloads) but over a shared drive. The `links.related` in the response will point to `/sharings/drives/:id/downloads/:secret/:filename` instead of `/files/downloads/...`.
 
+Drive tokens (share-interact) are checked against the member's effective read access on the target file; a target outside every sharing scope of the caller is answered `404 Not Found`.
+
 ### GET /sharings/drives/:id/downloads/:secret/:fake-name
 
 Download the file prepared by the `POST /sharings/drives/:id/downloads` call above. The `:fake-name` segment is ignored by the server — it exists solely so browsers use it as the suggested save-as filename.
@@ -417,6 +426,8 @@ This route is supported only for directory-root shared drives. File-root shared
 drives return `422 Unprocessable Entity`.
 
 The request body follows the same format as [`POST /files/archive`](files.md#post-filesarchive). The `links.related` in the response points to `/sharings/drives/:id/archive/:secret/:name.zip` instead of `/files/archive/...`.
+
+Drive tokens (share-interact) are checked against the member's effective read access on every target (`ids` and `files` entries); any target outside every sharing scope of the caller fails the whole request with `404 Not Found`. The `/` and `/files` pseudo-entries are governed by the VFS permission check only (they cover the whole account, outside any drive scope).
 
 #### Request
 
@@ -916,6 +927,10 @@ shared drive:
 - `POST /sharings/drives/:id/permissions`
 - `PATCH /sharings/drives/:id/permissions/:perm-id`
 - `DELETE /sharings/drives/:id/permissions/:perm-id`
+
+On every route, the targeted file or folder must be **effectively readable**
+by the caller (see the effective access rules in
+[Files and directories](#files-and-directories)).
 
 ### GET /sharings/drives/:id/permissions?ids=...
 

--- a/docs/shared-drives.md
+++ b/docs/shared-drives.md
@@ -337,6 +337,42 @@ Content-Type: application/vnd.api+json
 Unless stated otherwise, a permission on the whole `io.cozy.files` doctype is
 required to use the following routes.
 
+Authorization is resolved against the **effective access** of the target file
+or folder, not only the membership of the route's shared drive. The effective
+access combines every sharing scope applying to the target (the sharing of
+the route, plus any nested shared folder on its path) where the caller is a
+member:
+
+- read routes targeting a file or folder by its ID (`GET`/`HEAD
+  .../:file-id`, download, thumbnails) require effective read on the target;
+- `GET /sharings/drives/:id/metadata` requires effective read on the folder
+  or file resolved from its `Path` query parameter, and answers
+  `404 Not Found` when the path resolves outside every sharing scope of the
+  caller (so that the existence of paths outside the drive is not revealed);
+- write, update and delete routes (`POST`, `PUT`, `PATCH`, `DELETE`) require
+  effective write on the target file or folder;
+- creation and upload routes require effective write on the destination
+  folder;
+- `PATCH` (metadata update, rename) requires effective write on the source
+  item; a move (the `parent` relationship) additionally requires effective
+  write on the destination folder;
+- `POST /sharings/drives/:id/:file-id/copy` requires effective read on the
+  source file and effective write on the destination folder;
+- trash routes (`POST`/`DELETE /sharings/drives/:id/trash/:file-id`) target
+  files outside every sharing scope: restore and destroy require effective
+  write on the folder the file would be restored to (or on its first
+  existing ancestor when the original folder hierarchy was deleted, as the
+  restore recreates it there).
+
+`GET /sharings/drives/:id/_changes` is not resolved per target: it returns
+the changes of the whole drive to every member. In the additive access mode,
+every member of the drive can read every file of the drive anyway, so no
+per-line filtering is needed.
+
+A typical consequence: a member who is read-only on the drive root but has
+write access on a nested shared folder can write inside that folder through
+the drive routes, and is answered `403 Forbidden` elsewhere.
+
 For file-root shared drives (`drive_root_type = file`), iteration 1 currently
 supports only file-shaped routes. Directory-only routes return
 `422 Unprocessable Entity`. `_changes` and realtime are available with exact

--- a/docs/shared-drives.md
+++ b/docs/shared-drives.md
@@ -373,6 +373,18 @@ A typical consequence: a member who is read-only on the drive root but has
 write access on a nested shared folder can write inside that folder through
 the drive routes, and is answered `403 Forbidden` elsewhere.
 
+Known limitation: write routes without a file target (`POST
+/sharings/drives/:id/`, `POST /sharings/drives/:id/upload/metadata`, `POST
+/sharings/drives/:id/notes`) are authorized against the effective write
+access on the **drive root**, not on the actual destination folder declared
+in the request body (`dir_id`). As a consequence, a member who is read-only
+on the drive root but has write access on a nested shared folder cannot use
+these routes to target that folder: they get a `403 Forbidden` false
+negative. Clients in that situation should use a targeted route instead
+(`POST /sharings/drives/:id/:file-id` with the destination folder ID), which
+is checked against the effective access of the destination folder. This
+limitation will be lifted with `limited_access` support.
+
 For file-root shared drives (`drive_root_type = file`), iteration 1 currently
 supports only file-shaped routes. Directory-only routes return
 `422 Unprocessable Entity`. `_changes` and realtime are available with exact

--- a/model/sharing/effective_access.go
+++ b/model/sharing/effective_access.go
@@ -13,9 +13,9 @@ import (
 )
 
 // SharingScope describes a single sharing scope that applies to a target file
-// or folder. It is produced by AccessResolver.scopesFor and consumed by
-// Resolve to aggregate an EffectiveAccess. ReadOnly reflects the current
-// instance's membership for that scope (via Sharing.MemberFor).
+// or folder. It is produced by AccessResolver.scopesMatching and consumed by
+// resolve to aggregate an EffectiveAccess. ReadOnly reflects the matched
+// member's flag for that scope.
 type SharingScope struct {
 	SharingID  string
 	RootID     string
@@ -68,7 +68,23 @@ func NewAccessResolver(inst *instance.Instance) *AccessResolver {
 // is not a member are ignored. The highest permission wins: CanRead if at
 // least one applicable scope, CanWrite if at least one non-read-only scope.
 func (r *AccessResolver) Resolve(targetID string) (*EffectiveAccess, error) {
-	scopes, err := r.scopesFor(targetID)
+	return r.resolve(targetID, func(s *Sharing) *Member {
+		return s.MemberFor(r.inst)
+	})
+}
+
+// ResolveForMember returns the effective access for the given sharing member
+// on the target file or folder. The member is matched across sharings by
+// email or instance host (see Sharing.MemberMatching), which allows checking
+// the access of a specific recipient on the owner's instance.
+func (r *AccessResolver) ResolveForMember(targetID string, member *Member) (*EffectiveAccess, error) {
+	return r.resolve(targetID, func(s *Sharing) *Member {
+		return s.MemberMatching(member)
+	})
+}
+
+func (r *AccessResolver) resolve(targetID string, memberOf func(*Sharing) *Member) (*EffectiveAccess, error) {
+	scopes, err := r.scopesMatching(targetID, memberOf)
 	if err != nil {
 		return nil, err
 	}
@@ -91,11 +107,11 @@ type rootInfo struct {
 	RootName string
 }
 
-// scopesFor loads the target, builds ancestor paths, finds shared roots on
-// the path, adds the target's own file share if any, bulk-loads sharings,
-// filters to active additive ones where the current instance is a member,
-// and returns the resulting scopes.
-func (r *AccessResolver) scopesFor(targetID string) ([]SharingScope, error) {
+// scopesMatching loads the target, builds ancestor paths, finds shared roots
+// on the path, adds the target's own file share if any, bulk-loads sharings,
+// filters to active additive ones, and returns the scopes where memberOf
+// resolves a member (nil member = scope does not apply).
+func (r *AccessResolver) scopesMatching(targetID string, memberOf func(*Sharing) *Member) ([]SharingScope, error) {
 	sharings, rootBySharing, err := r.applicableSharings(targetID)
 	if err != nil {
 		return nil, err
@@ -107,7 +123,7 @@ func (r *AccessResolver) scopesFor(targetID string) ([]SharingScope, error) {
 		if !ok {
 			continue
 		}
-		member := s.MemberFor(r.inst)
+		member := memberOf(s)
 		if member == nil {
 			continue
 		}
@@ -251,7 +267,7 @@ func (r *AccessResolver) ancestorPaths(targetPath string, targetIsDir bool) []st
 
 // loadSharings bulk-loads sharings by ID and keeps only the active additive
 // ones. limited_access sharings are dropped in v1. Membership filtering is
-// done by the caller (scopesFor) so this helper stays reusable.
+// done by the caller (scopesMatching) so this helper stays reusable.
 func (r *AccessResolver) loadSharings(ids []string) ([]*Sharing, error) {
 	sharings, err := FindSharings(r.inst, ids)
 	if err != nil {

--- a/model/sharing/effective_access.go
+++ b/model/sharing/effective_access.go
@@ -14,14 +14,15 @@ import (
 
 // SharingScope describes a single sharing scope that applies to a target file
 // or folder. It is produced by AccessResolver.scopesMatching and consumed by
-// resolve to aggregate an EffectiveAccess. ReadOnly reflects the matched
-// member's flag for that scope.
+// resolve to aggregate an EffectiveAccess. Sharing is the backing sharing
+// document and Member the matching member's entry inside it (the same object
+// as Sharing.Members[i]): the pair is coherent by construction.
 type SharingScope struct {
-	SharingID  string
+	Sharing    *Sharing
+	Member     *Member
 	RootID     string
 	RootPath   string
 	AccessMode string
-	ReadOnly   bool
 }
 
 // EffectiveAccess is the merged result of all applicable additive sharing
@@ -90,9 +91,9 @@ func (r *AccessResolver) resolve(targetID string, memberOf func(*Sharing) *Membe
 	}
 	ea := &EffectiveAccess{SourceSharingIDs: make([]string, 0, len(scopes))}
 	for _, sc := range scopes {
-		ea.SourceSharingIDs = append(ea.SourceSharingIDs, sc.SharingID)
+		ea.SourceSharingIDs = append(ea.SourceSharingIDs, sc.Sharing.SID)
 		ea.CanRead = true
-		if !sc.ReadOnly {
+		if !sc.Member.ReadOnly {
 			ea.CanWrite = true
 		}
 	}
@@ -128,11 +129,11 @@ func (r *AccessResolver) scopesMatching(targetID string, memberOf func(*Sharing)
 			continue
 		}
 		scopes = append(scopes, SharingScope{
-			SharingID:  s.SID,
+			Sharing:    s,
+			Member:     member,
 			RootID:     info.RootID,
 			RootPath:   info.RootPath,
 			AccessMode: s.EffectiveAccessMode(),
-			ReadOnly:   member.ReadOnly,
 		})
 	}
 	return scopes, nil
@@ -287,6 +288,33 @@ func (r *AccessResolver) loadSharings(ids []string) ([]*Sharing, error) {
 		kept = append(kept, s)
 	}
 	return kept, nil
+}
+
+// NearestWritableSharing returns the sharing scope granting write access to
+// the member that is nearest to the target: the shared root enclosing the
+// target with the deepest path. Every applicable scope covers the target by
+// construction, so the nearest one is the narrowest: a sharecode minted from
+// it (see FileOpener.GetSharecode) lets the member act on the target without
+// granting anything beyond their effective write scope. Returns nil when no
+// applicable scope grants the member write.
+func (r *AccessResolver) NearestWritableSharing(targetID string, member *Member) (*SharingScope, error) {
+	scopes, err := r.scopesMatching(targetID, func(s *Sharing) *Member {
+		return s.MemberMatching(member)
+	})
+	if err != nil {
+		return nil, err
+	}
+	var nearest *SharingScope
+	for i := range scopes {
+		sc := &scopes[i]
+		if sc.Member.ReadOnly {
+			continue
+		}
+		if nearest == nil || len(sc.RootPath) > len(nearest.RootPath) {
+			nearest = sc
+		}
+	}
+	return nearest, nil
 }
 
 // NearestRestrictiveBoundary returns the closest limited_access boundary

--- a/model/sharing/effective_access_test.go
+++ b/model/sharing/effective_access_test.go
@@ -38,7 +38,7 @@ func TestAccessResolver_AncestorsOnly(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, scopes, 1)
-	assert.Equal(t, s.SID, scopes[0].SharingID)
+	assert.Equal(t, s.SID, scopes[0].Sharing.SID)
 	assert.Equal(t, parent.ID(), scopes[0].RootID)
 	assert.Equal(t, parent.Fullpath, scopes[0].RootPath)
 
@@ -76,7 +76,7 @@ func TestAccessResolver_SelfAndAncestor(t *testing.T) {
 	require.Len(t, scopes, 2)
 	got := map[string]SharingScope{}
 	for _, sc := range scopes {
-		got[sc.SharingID] = sc
+		got[sc.Sharing.SID] = sc
 	}
 	assert.Contains(t, got, sParent.SID)
 	assert.Contains(t, got, sChild.SID)
@@ -160,7 +160,7 @@ func TestAccessResolver_FileTargetWithOwnShare(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, scopes, 1)
-	assert.Equal(t, s.SID, scopes[0].SharingID)
+	assert.Equal(t, s.SID, scopes[0].Sharing.SID)
 	assert.Equal(t, file.ID(), scopes[0].RootID)
 }
 
@@ -187,7 +187,7 @@ func TestAccessResolver_FileTargetInSharedDir(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, scopes, 1)
-	assert.Equal(t, s.SID, scopes[0].SharingID)
+	assert.Equal(t, s.SID, scopes[0].Sharing.SID)
 	assert.Equal(t, parent.ID(), scopes[0].RootID)
 }
 
@@ -217,7 +217,7 @@ func TestAccessResolver_FileTargetAdditive(t *testing.T) {
 	require.Len(t, scopes, 2)
 	got := map[string]SharingScope{}
 	for _, sc := range scopes {
-		got[sc.SharingID] = sc
+		got[sc.Sharing.SID] = sc
 	}
 	assert.Contains(t, got, sParent.SID)
 	assert.Contains(t, got, sFile.SID)
@@ -549,5 +549,90 @@ func TestAccessResolver_ResolveForMember(t *testing.T) {
 		ea, err := resolver.ResolveForMember(topFile.ID(), nil)
 		require.NoError(t, err)
 		assert.False(t, ea.CanRead)
+	})
+}
+
+func TestAccessResolver_NearestWritableSharing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{"nested.txt": H{}}, "top.txt": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+	nestedFile, err := fs.FileByPath(child.Fullpath + "/nested.txt")
+	require.NoError(t, err)
+	topFile, err := fs.FileByPath(parent.Fullpath + "/top.txt")
+	require.NoError(t, err)
+
+	daveInstance := "https://dave.example.net"
+	dave := &Member{Email: "dave@example.net", Instance: daveInstance}
+	sParent := createActiveRecipientSharing(t, inst, parent.ID(), false, daveInstance)
+	sChild := createActiveRecipientSharing(t, inst, child.ID(), false, daveInstance)
+
+	resolver := NewAccessResolver(inst)
+
+	t.Run("DeepestWritableScopeWins", func(t *testing.T) {
+		sc, err := resolver.NearestWritableSharing(nestedFile.ID(), dave)
+		require.NoError(t, err)
+		require.NotNil(t, sc)
+		assert.Equal(t, sChild.SID, sc.Sharing.SID)
+		assert.Equal(t, child.ID(), sc.RootID)
+		// The member entry is the one inside the returned sharing.
+		assert.Same(t, &sc.Sharing.Members[1], sc.Member)
+	})
+
+	t.Run("OuterScopeWhenNoNestedOneApplies", func(t *testing.T) {
+		sc, err := resolver.NearestWritableSharing(topFile.ID(), dave)
+		require.NoError(t, err)
+		require.NotNil(t, sc)
+		assert.Equal(t, sParent.SID, sc.Sharing.SID)
+		assert.Equal(t, parent.ID(), sc.RootID)
+	})
+}
+
+func TestAccessResolver_NearestWritableSharingSkipsReadOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{"nested.txt": H{}}, "top.txt": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+	nestedFile, err := fs.FileByPath(child.Fullpath + "/nested.txt")
+	require.NoError(t, err)
+	topFile, err := fs.FileByPath(parent.Fullpath + "/top.txt")
+	require.NoError(t, err)
+
+	daveInstance := "https://dave.example.net"
+	dave := &Member{Email: "dave@example.net", Instance: daveInstance}
+	createActiveRecipientSharing(t, inst, parent.ID(), true, daveInstance)
+	sChild := createActiveRecipientSharing(t, inst, child.ID(), false, daveInstance)
+
+	resolver := NewAccessResolver(inst)
+
+	t.Run("NestedScopeSkipsReadOnlyRoot", func(t *testing.T) {
+		sc, err := resolver.NearestWritableSharing(nestedFile.ID(), dave)
+		require.NoError(t, err)
+		require.NotNil(t, sc)
+		assert.Equal(t, sChild.SID, sc.Sharing.SID)
+	})
+
+	t.Run("NilWhenOnlyReadOnlyApplies", func(t *testing.T) {
+		sc, err := resolver.NearestWritableSharing(topFile.ID(), dave)
+		require.NoError(t, err)
+		assert.Nil(t, sc)
 	})
 }

--- a/model/sharing/effective_access_test.go
+++ b/model/sharing/effective_access_test.go
@@ -33,7 +33,9 @@ func TestAccessResolver_AncestorsOnly(t *testing.T) {
 	s := createActiveDirSharing(t, inst, parent.ID())
 
 	resolver := NewAccessResolver(inst)
-	scopes, err := resolver.scopesFor(child.ID())
+	scopes, err := resolver.scopesMatching(child.ID(), func(s *Sharing) *Member {
+		return s.MemberFor(inst)
+	})
 	require.NoError(t, err)
 	require.Len(t, scopes, 1)
 	assert.Equal(t, s.SID, scopes[0].SharingID)
@@ -67,7 +69,9 @@ func TestAccessResolver_SelfAndAncestor(t *testing.T) {
 	sChild := createActiveDirSharing(t, inst, child.ID())
 
 	resolver := NewAccessResolver(inst)
-	scopes, err := resolver.scopesFor(child.ID())
+	scopes, err := resolver.scopesMatching(child.ID(), func(s *Sharing) *Member {
+		return s.MemberFor(inst)
+	})
 	require.NoError(t, err)
 	require.Len(t, scopes, 2)
 	got := map[string]SharingScope{}
@@ -99,7 +103,9 @@ func TestAccessResolver_SkipsInactive(t *testing.T) {
 	require.NoError(t, couchdb.UpdateDoc(inst, s))
 
 	resolver := NewAccessResolver(inst)
-	scopes, err := resolver.scopesFor(child.ID())
+	scopes, err := resolver.scopesMatching(child.ID(), func(s *Sharing) *Member {
+		return s.MemberFor(inst)
+	})
 	require.NoError(t, err)
 	assert.Empty(t, scopes)
 }
@@ -124,7 +130,9 @@ func TestAccessResolver_SkipsLimitedAccess(t *testing.T) {
 	require.NoError(t, couchdb.UpdateDoc(inst, s))
 
 	resolver := NewAccessResolver(inst)
-	scopes, err := resolver.scopesFor(child.ID())
+	scopes, err := resolver.scopesMatching(child.ID(), func(s *Sharing) *Member {
+		return s.MemberFor(inst)
+	})
 	require.NoError(t, err)
 	assert.Empty(t, scopes)
 }
@@ -147,7 +155,9 @@ func TestAccessResolver_FileTargetWithOwnShare(t *testing.T) {
 	s := createActiveFileSharing(t, inst, file.ID())
 
 	resolver := NewAccessResolver(inst)
-	scopes, err := resolver.scopesFor(file.ID())
+	scopes, err := resolver.scopesMatching(file.ID(), func(s *Sharing) *Member {
+		return s.MemberFor(inst)
+	})
 	require.NoError(t, err)
 	require.Len(t, scopes, 1)
 	assert.Equal(t, s.SID, scopes[0].SharingID)
@@ -172,7 +182,9 @@ func TestAccessResolver_FileTargetInSharedDir(t *testing.T) {
 	s := createActiveDirSharing(t, inst, parent.ID())
 
 	resolver := NewAccessResolver(inst)
-	scopes, err := resolver.scopesFor(file.ID())
+	scopes, err := resolver.scopesMatching(file.ID(), func(s *Sharing) *Member {
+		return s.MemberFor(inst)
+	})
 	require.NoError(t, err)
 	require.Len(t, scopes, 1)
 	assert.Equal(t, s.SID, scopes[0].SharingID)
@@ -198,7 +210,9 @@ func TestAccessResolver_FileTargetAdditive(t *testing.T) {
 	sFile := createActiveFileSharing(t, inst, file.ID())
 
 	resolver := NewAccessResolver(inst)
-	scopes, err := resolver.scopesFor(file.ID())
+	scopes, err := resolver.scopesMatching(file.ID(), func(s *Sharing) *Member {
+		return s.MemberFor(inst)
+	})
 	require.NoError(t, err)
 	require.Len(t, scopes, 2)
 	got := map[string]SharingScope{}
@@ -471,4 +485,69 @@ func createSharing(t *testing.T, inst *instance.Instance, rootID string, owner b
 	require.NoError(t, couchdb.CreateDoc(inst, s))
 	require.NoError(t, s.AddReferenceForSharing(inst, &s.Rules[0]))
 	return s
+}
+
+func TestAccessResolver_ResolveForMember(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fs := inst.VFS()
+
+	tree := H{"parent/": H{"child/": H{"nested.txt": H{}}, "top.txt": H{}}}
+	parent := createTree(t, fs, tree, consts.RootDirID)
+	child, err := fs.DirByPath(parent.Fullpath + "/child")
+	require.NoError(t, err)
+	nestedFile, err := fs.FileByPath(child.Fullpath + "/nested.txt")
+	require.NoError(t, err)
+	topFile, err := fs.FileByPath(parent.Fullpath + "/top.txt")
+	require.NoError(t, err)
+
+	daveInstance := "https://dave.example.net"
+	createActiveRecipientSharing(t, inst, parent.ID(), true, daveInstance)
+	createActiveRecipientSharing(t, inst, child.ID(), false, daveInstance)
+
+	resolver := NewAccessResolver(inst)
+	dave := &Member{Email: "dave@example.net", Instance: daveInstance}
+
+	t.Run("WriteViaNestedScope", func(t *testing.T) {
+		ea, err := resolver.ResolveForMember(nestedFile.ID(), dave)
+		require.NoError(t, err)
+		assert.True(t, ea.CanRead)
+		assert.True(t, ea.CanWrite)
+		assert.True(t, ea.Can(permission.GET))
+		assert.True(t, ea.Can(permission.PATCH))
+		assert.Len(t, ea.SourceSharingIDs, 2)
+	})
+
+	t.Run("ReadOnlyViaRootScope", func(t *testing.T) {
+		ea, err := resolver.ResolveForMember(topFile.ID(), dave)
+		require.NoError(t, err)
+		assert.True(t, ea.CanRead)
+		assert.False(t, ea.CanWrite)
+		assert.False(t, ea.Can(permission.PATCH))
+	})
+
+	t.Run("MatchingByInstanceHost", func(t *testing.T) {
+		ea, err := resolver.ResolveForMember(topFile.ID(), &Member{Instance: daveInstance})
+		require.NoError(t, err)
+		assert.True(t, ea.CanRead)
+	})
+
+	t.Run("NotAMember", func(t *testing.T) {
+		stranger := &Member{Email: "stranger@example.net", Instance: "https://stranger.example.net"}
+		ea, err := resolver.ResolveForMember(topFile.ID(), stranger)
+		require.NoError(t, err)
+		assert.False(t, ea.CanRead)
+		assert.False(t, ea.CanWrite)
+	})
+
+	t.Run("NilMember", func(t *testing.T) {
+		ea, err := resolver.ResolveForMember(topFile.ID(), nil)
+		require.NoError(t, err)
+		assert.False(t, ea.CanRead)
+	})
 }

--- a/model/sharing/member.go
+++ b/model/sharing/member.go
@@ -683,6 +683,34 @@ func (s *Sharing) MemberFor(inst *instance.Instance) *Member {
 	return nil
 }
 
+// MemberMatching returns the member of the sharing that corresponds to the
+// given reference member, matched by email or by instance host. It is used to
+// follow a member across several sharings (e.g. nested shared folders).
+// Only ready members are returned: a recipient that has not accepted the
+// sharing (pending, seen) holds no drive token and must not count in the
+// effective access resolution. Revoked members are not returned either, and
+// neither is the owner entry: a recipient identity must never resolve to the
+// owner (who is never read-only).
+func (s *Sharing) MemberMatching(ref *Member) *Member {
+	if ref == nil {
+		return nil
+	}
+	refHost := ref.InstanceHost()
+	for i := range s.Members {
+		m := &s.Members[i]
+		if m.Status != MemberStatusReady {
+			continue
+		}
+		if ref.Email != "" && m.Email == ref.Email {
+			return m
+		}
+		if refHost != "" && m.InstanceHost() == refHost {
+			return m
+		}
+	}
+	return nil
+}
+
 // FindMemberBySharecode returns the member that is linked to the sharing by
 // the given sharecode
 func (s *Sharing) FindMemberBySharecode(db prefixer.Prefixer, sharecode string) (*Member, error) {

--- a/model/sharing/member_test.go
+++ b/model/sharing/member_test.go
@@ -581,3 +581,28 @@ func TestMemberFor(t *testing.T) {
 		assert.Nil(t, s.MemberFor(inst))
 	})
 }
+
+func TestMemberMatching(t *testing.T) {
+	s := &Sharing{Members: []Member{
+		{Status: MemberStatusOwner, Name: "Alice", Email: "alice@example.net", Instance: "https://alice.example.net"},
+		{Status: MemberStatusReady, Name: "Dave", Email: "dave@example.net", Instance: "https://dave.example.net"},
+		{Status: MemberStatusRevoked, Name: "Eve", Email: "eve@example.net", Instance: "https://eve.example.net"},
+		{Status: MemberStatusSeen, Name: "Frank", Email: "frank@example.net", Instance: "https://frank.example.net"},
+	}}
+
+	byEmail := s.MemberMatching(&Member{Email: "dave@example.net"})
+	require.NotNil(t, byEmail)
+	assert.Equal(t, "Dave", byEmail.Name)
+
+	byInstance := s.MemberMatching(&Member{Instance: "https://dave.example.net"})
+	require.NotNil(t, byInstance)
+	assert.Equal(t, "dave@example.net", byInstance.Email)
+
+	assert.Nil(t, s.MemberMatching(&Member{Email: "eve@example.net"}), "revoked members must not match")
+	assert.Nil(t, s.MemberMatching(&Member{Email: "frank@example.net"}), "members who have not accepted the sharing must not match")
+	assert.Nil(t, s.MemberMatching(&Member{Email: "alice@example.net"}), "the owner entry must not match")
+	assert.Nil(t, s.MemberMatching(&Member{Instance: "https://alice.example.net"}), "the owner entry must not match")
+	assert.Nil(t, s.MemberMatching(&Member{Email: "stranger@example.net"}))
+	assert.Nil(t, s.MemberMatching(nil))
+	assert.Nil(t, s.MemberMatching(&Member{}))
+}

--- a/model/sharing/open_file.go
+++ b/model/sharing/open_file.go
@@ -28,6 +28,12 @@ type FileOpener struct {
 	Code      string
 	ClientID  string
 	MemberKey string
+
+	// InteractToken marks a share-interact token on a drive: MemberKey
+	// identifies the member, but readOnly is decided by the caller
+	// (effective access) and member.ReadOnly must not force it — a member
+	// read-only on the drive can have effective write on a nested folder.
+	InteractToken bool
 }
 
 // NewFileOpener returns a FileOpener for the given file on the current instance.
@@ -124,6 +130,13 @@ func (o *FileOpener) CheckPermission(pdoc *permission.Permission, sharingID stri
 		}
 	}
 
+	// A share-interact token on a drive identifies the member via MemberKey
+	// (set above from the interact codes); flag it so GetSharecode does not
+	// apply member.ReadOnly: readOnly comes from the caller.
+	if pdoc.Type == permission.TypeShareInteract && o.Sharing != nil && o.Sharing.Drive {
+		o.InteractToken = true
+	}
+
 	// If a file is opened via a token for cozy-to-cozy sharing, then the file
 	// must be in this sharing, or the stack should refuse to open the file.
 	if sharingID != "" && o.Sharing != nil && o.Sharing.ID() == sharingID {
@@ -155,7 +168,9 @@ func (o *FileOpener) ShouldOpenLocally() bool {
 }
 
 // GetSharecode returns a sharecode that can be used to open the note with the
-// permissions of the member.
+// permissions of the member. If the caller already decided the read-only
+// mode (via the open handler's effective access check), it is respected and
+// not recalculated; it must previously be set by the caller via ReadOnly.
 func (o *FileOpener) GetSharecode(memberIndex int, readOnly bool) (string, error) {
 	s := o.Sharing
 	if s == nil || (!s.Drive && o.ClientID == "" && o.MemberKey == "") {
@@ -165,19 +180,25 @@ func (o *FileOpener) GetSharecode(memberIndex int, readOnly bool) (string, error
 	var member *Member
 	var err error
 	if o.MemberKey != "" {
-		// Preview of a cozy-to-cozy sharing
+		// Preview of cozy-to-cozy sharing, or share-interact token on a
+		// drive; MemberKey is email or instance, and its lookup finds the
+		// member. memberIndex is reset to the member's position, needed for
+		// getPreviewCode member-index matching.
 		for i, m := range s.Members {
 			if m.Instance == o.MemberKey || m.Email == o.MemberKey {
 				member = &s.Members[i]
+				memberIndex = i
 			}
 		}
 		if member == nil {
 			return "", ErrMemberNotFound
 		}
-		if member.ReadOnly {
-			readOnly = true
-		} else {
-			readOnly = s.ReadOnlyRules()
+		if !o.InteractToken {
+			if member.ReadOnly {
+				readOnly = true
+			} else {
+				readOnly = s.ReadOnlyRules()
+			}
 		}
 	} else if s.Owner {
 		member, err = s.FindMemberByInboundClientID(o.ClientID)
@@ -199,6 +220,21 @@ func (o *FileOpener) GetSharecode(memberIndex int, readOnly bool) (string, error
 
 	if readOnly {
 		return o.getPreviewCode(member, memberIndex)
+	}
+	// A drive member's effective write on the file may come from another
+	// sharing than the token's drive (e.g. a nested drive): mint the code
+	// from the nearest sharing scope that grants the write, else the token's
+	// sharing code would grant write access on the whole drive, outside the
+	// member's effective scope.
+	if o.InteractToken {
+		// ponytail: the web layer already resolved the effective access to
+		// decide readOnly; caching it across the layers would mean plumbing
+		// the result through the notes/office/editor handlers.
+		if sc, err := NewAccessResolver(o.Inst).NearestWritableSharing(o.File.ID(), member); err == nil && sc != nil {
+			o.Sharing = sc.Sharing
+			member = sc.Member
+			memberIndex = -1 // the code is keyed by the member email or instance
+		}
 	}
 	return o.Sharing.GetInteractCode(o.Inst, member, memberIndex)
 }

--- a/web/editor/editor.go
+++ b/web/editor/editor.go
@@ -18,6 +18,12 @@ import (
 // OpenURL is the API handler for GET /editor/:file-id/open. It returns the
 // parameters to build the URL where the file can be opened by an editor.
 func OpenURL(c echo.Context) error {
+	return OpenURLWithReadOnly(c, c.QueryParam("ReadOnly") == "true")
+}
+
+// OpenURLWithReadOnly is like OpenURL, with the read-only flag given
+// explicitly instead of read from the query.
+func OpenURLWithReadOnly(c echo.Context, readOnly bool) error {
 	inst := middlewares.GetInstance(c)
 	fileID := c.Param("file-id")
 	open, err := sharing.OpenEditor(inst, fileID)
@@ -30,7 +36,6 @@ func OpenURL(c echo.Context) error {
 		return err
 	}
 	memberIndex, _ := strconv.Atoi(c.QueryParam("MemberIndex"))
-	readOnly := c.QueryParam("ReadOnly") == "true"
 
 	// If a directory is shared by link and contains the file, it can be opened
 	// with the same sharecode as the directory. The sharecode is also used to

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -1494,6 +1494,20 @@ func ReadTrashFilesHandler(c echo.Context) error {
 
 // Restore handle POST requests on /files/trash/file-id and
 // can be used to restore a file or directory from the trash.
+//
+// driveMemberAuthorized reports whether the request carries a shared-drive
+// member token reaching this handler via a drive route: the route guard in
+// web/sharings/drives.go has already authorized it, and the VFS permission
+// check cannot succeed on a trashed file (no referenced_by, path in the
+// trash), so it is skipped.
+func driveMemberAuthorized(c echo.Context, sharedDrive *sharing.Sharing) bool {
+	if sharedDrive == nil {
+		return false
+	}
+	pdoc, err := middlewares.GetPermission(c)
+	return err == nil && pdoc.Type == permission.TypeShareInteract
+}
+
 func Restore(c echo.Context, sharedDrive *sharing.Sharing) error {
 	instance := middlewares.GetInstance(c)
 
@@ -1504,9 +1518,11 @@ func Restore(c echo.Context, sharedDrive *sharing.Sharing) error {
 		return WrapVfsError(err)
 	}
 
-	err = checkPerm(c, permission.PATCH, dir, file)
-	if err != nil {
-		return err
+	if !driveMemberAuthorized(c, sharedDrive) {
+		err = checkPerm(c, permission.PATCH, dir, file)
+		if err != nil {
+			return err
+		}
 	}
 
 	if dir != nil {
@@ -1575,6 +1591,10 @@ func ClearTrashHandler(c echo.Context) error {
 
 // DestroyFileHandler handles DELETE request to clear one element from the trash
 func DestroyFileHandler(c echo.Context) error {
+	return Destroy(c, nil)
+}
+
+func Destroy(c echo.Context, sharedDrive *sharing.Sharing) error {
 	inst := middlewares.GetInstance(c)
 
 	fileID := c.Param("file-id")
@@ -1584,9 +1604,12 @@ func DestroyFileHandler(c echo.Context) error {
 		return WrapVfsError(err)
 	}
 
-	err = checkPerm(c, permission.DELETE, dir, file)
-	if err != nil {
-		return err
+	// Same skip as Restore: see driveMemberAuthorized.
+	if !driveMemberAuthorized(c, sharedDrive) {
+		err = checkPerm(c, permission.DELETE, dir, file)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Check antivirus status for files

--- a/web/notes/notes.go
+++ b/web/notes/notes.go
@@ -321,6 +321,12 @@ func ForceNoteSync(c echo.Context) error {
 // OpenNoteURL is the API handler for GET /notes/:id/open. It returns the
 // parameters to build the URL where the note can be opened.
 func OpenNoteURL(c echo.Context) error {
+	return OpenNoteURLWithReadOnly(c, c.QueryParam("ReadOnly") == "true")
+}
+
+// OpenNoteURLWithReadOnly is like OpenNoteURL, with the read-only flag given
+// explicitly instead of read from the query.
+func OpenNoteURLWithReadOnly(c echo.Context, readOnly bool) error {
 	inst := middlewares.GetInstance(c)
 	fileID := c.Param("file-id")
 	open, err := sharing.OpenNote(inst, fileID)
@@ -333,7 +339,6 @@ func OpenNoteURL(c echo.Context) error {
 		return err
 	}
 	memberIndex, _ := strconv.Atoi(c.QueryParam("MemberIndex"))
-	readOnly := c.QueryParam("ReadOnly") == "true"
 
 	// If a directory is shared by link and contains a note, the note can be
 	// opened with the same sharecode as the directory. The sharecode is also

--- a/web/office/office.go
+++ b/web/office/office.go
@@ -19,6 +19,12 @@ import (
 
 // Open returns the parameters to open an office document.
 func Open(c echo.Context) error {
+	return OpenWithReadOnly(c, c.QueryParam("ReadOnly") == "true")
+}
+
+// OpenWithReadOnly is like Open, with the read-only flag given explicitly
+// instead of read from the query.
+func OpenWithReadOnly(c echo.Context, readOnly bool) error {
 	inst := middlewares.GetInstance(c)
 	fileID := c.Param("file-id")
 	open, err := sharing.OpenOffice(inst, fileID)
@@ -30,7 +36,6 @@ func Open(c echo.Context) error {
 		return err
 	}
 	memberIndex, _ := strconv.Atoi(c.QueryParam("MemberIndex"))
-	readOnly := c.QueryParam("ReadOnly") == "true"
 
 	// If a directory is shared by link and contains an office document, the
 	// document can be opened with the same sharecode as the directory. The

--- a/web/sharings/drives.go
+++ b/web/sharings/drives.go
@@ -255,8 +255,56 @@ func HeadDirOrFile(c echo.Context, inst *instance.Instance, s *sharing.Sharing) 
 	return nil
 }
 
+// authorizeDriveTarget resolves the effective access of the given drive
+// member on the target; 404 hides targets outside every sharing scope, to
+// avoid revealing which paths exist on the instance.
+func authorizeDriveTarget(inst *instance.Instance, member *sharing.Member, targetID string) (*sharing.EffectiveAccess, error) {
+	ea, err := sharing.NewAccessResolver(inst).ResolveForMember(targetID, member)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, jsonapi.NotFound(errors.New("shared drive target not found"))
+		}
+		return nil, wrapErrors(err)
+	}
+	if !ea.CanRead {
+		return nil, jsonapi.NotFound(errors.New("shared drive target not found"))
+	}
+	return ea, nil
+}
+
+// checkDriveMemberRead asserts the calling drive member (if any) has
+// effective read access on the target. No-op for non-member tokens (owner,
+// share-by-link).
+func checkDriveMemberRead(c echo.Context, inst *instance.Instance, targetID string) error {
+	member := GetSharedDriveMember(c)
+	if member == nil {
+		return nil
+	}
+	_, err := authorizeDriveTarget(inst, member, targetID)
+	return err
+}
+
 // ReadMetadataFromPath allows to get file/dir information for a path.
 func ReadMetadataFromPath(c echo.Context, inst *instance.Instance, s *sharing.Sharing) error {
+	// Drive tokens are checked against the member's effective read access on
+	// the resolved target; other tokens keep the VFS permission check done
+	// by files.ReadMetadataFromPath. A target outside every sharing scope is
+	// answered 404 to avoid revealing which paths exist on the instance.
+	if GetSharedDriveMember(c) != nil && c.QueryParam("Path") != "" {
+		dir, file, err := inst.VFS().DirOrFileByPath(c.QueryParam("Path"))
+		if err != nil {
+			return jsonapi.NotFound(errors.New("shared drive target not found"))
+		}
+		var targetID string
+		if dir != nil {
+			targetID = dir.DocID
+		} else {
+			targetID = file.DocID
+		}
+		if err := checkDriveMemberRead(c, inst, targetID); err != nil {
+			return err
+		}
+	}
 	return files.ReadMetadataFromPath(c, s)
 }
 
@@ -339,6 +387,14 @@ func ModifyMetadataByIDHandler(c echo.Context, inst *instance.Instance, s *shari
 		rootID, err := s.DriveRootID()
 		if err == nil && c.Param("file-id") == rootID {
 			return jsonapi.NewError(http.StatusUnprocessableEntity, "cannot move the root of a shared drive")
+		}
+		// ponytail: destination check lives in the handler, not in
+		// guardSharedDriveRouteForMember, because the guard cannot read the
+		// request body without consuming it.
+		if member := GetSharedDriveMember(c); member != nil {
+			if err := checkEffectiveAccessForMember(inst, *patch.DirID, permission.POST, member); err != nil {
+				return err
+			}
 		}
 	}
 	if err = applyPatch(c, inst.VFS(), patch); err != nil {
@@ -481,7 +537,7 @@ func CreationHandler(c echo.Context, inst *instance.Instance, s *sharing.Sharing
 // DestroyFileHandler handles DELETE requests to clear one element from the
 // trash.
 func DestroyFileHandler(c echo.Context, inst *instance.Instance, s *sharing.Sharing) error {
-	return files.DestroyFileHandler(c)
+	return files.Destroy(c, s)
 }
 
 // OverwriteFileContentHandler handles PUT requests to overwrite the content of
@@ -708,7 +764,19 @@ func validateSharedDrivePermissionTargetID(
 	if err != nil {
 		return jsonapi.BadRequest(errors.New("file is not within the shared drive"))
 	}
-	if dir != nil {
+
+	// The caller must be able to read the target. Drive tokens are checked
+	// against the member's effective access; other tokens keep the VFS
+	// permission check.
+	member, err := sharedDriveInteractMember(c, inst, s)
+	if err != nil {
+		return err
+	}
+	if member != nil {
+		if err := checkEffectiveAccessForMember(inst, fileID, permission.GET, member); err != nil {
+			return err
+		}
+	} else if dir != nil {
 		if err := middlewares.AllowVFS(c, permission.GET, dir); err != nil {
 			return err
 		}
@@ -1395,6 +1463,14 @@ func proxy(fn func(c echo.Context, inst *instance.Instance, s *sharing.Sharing) 
 		}
 
 		if s.Owner {
+			member, err := sharedDriveInteractMember(c, inst, s)
+			if err != nil {
+				return err
+			}
+			SetSharedDriveMember(c, member)
+			if err := guardSharedDriveRouteForMember(c, inst, s); err != nil {
+				return err
+			}
 			return fn(c, inst, s)
 		}
 
@@ -1409,13 +1485,6 @@ func proxy(fn func(c echo.Context, inst *instance.Instance, s *sharing.Sharing) 
 			verb := permission.Verb(method)
 			if err := middlewares.AllowWholeType(c, verb, consts.Files); err != nil {
 				return err
-			}
-
-			if shouldCheck, requireWrite := sharedDrivePermissionCheck(method, c.Request().URL.Path); shouldCheck {
-				_, err := checkSharedDrivePermission(inst, c.Param("id"), requireWrite)
-				if err != nil {
-					return err
-				}
 			}
 		}
 
@@ -1437,6 +1506,20 @@ func proxy(fn func(c echo.Context, inst *instance.Instance, s *sharing.Sharing) 
 			middlewares.ForcePermission(c, nil)
 			c.Set("claims", nil)
 			middlewares.SetInstance(c, owner)
+			ownerSharing, err := sharing.FindSharing(owner, c.Param("id"))
+			if err != nil {
+				return wrapErrors(err)
+			}
+			// The member must be resolved against the owner's instance and
+			// sharing: the recipient-side member would authorize nothing here.
+			ownerMember, err := sharedDriveInteractMember(c, owner, ownerSharing)
+			if err != nil {
+				return err
+			}
+			SetSharedDriveMember(c, ownerMember)
+			if err := guardSharedDriveRouteForMember(c, owner, ownerSharing); err != nil {
+				return err
+			}
 			return fn(c, owner, s)
 		}
 
@@ -1454,6 +1537,210 @@ func proxy(fn func(c echo.Context, inst *instance.Instance, s *sharing.Sharing) 
 		proxy.ErrorLog = log.New(logger, "", 0)
 		proxy.ServeHTTP(c.Response(), c.Request())
 		return nil
+	}
+}
+
+// contextDriveMember is the echo context key where proxy stores the drive
+// member resolved for the request, once, before the guard and handlers run.
+const contextDriveMember = "drive-member"
+
+// SetSharedDriveMember stores the resolved drive member in the echo context.
+// Called by proxy right before the guard runs, on the instance that
+// authorizes the request (the owner's). A nil member marks a resolved
+// non-member request (owner's own token, share-by-link).
+func SetSharedDriveMember(c echo.Context, member *sharing.Member) {
+	c.Set(contextDriveMember, member)
+}
+
+// GetSharedDriveMember returns the drive member stored by proxy, or nil for
+// non-member tokens. Only valid on drive routes, after proxy ran.
+func GetSharedDriveMember(c echo.Context) *sharing.Member {
+	member, _ := c.Get(contextDriveMember).(*sharing.Member)
+	return member
+}
+
+// sharedDriveInteractMember resolves the sharing member behind the request
+// token. It returns (nil, nil) when the request does not carry a drive token
+// (share-interact): the owner's own tokens and public secret routes carry no
+// member identity and are not constrained by effective access.
+func sharedDriveInteractMember(c echo.Context, inst *instance.Instance, s *sharing.Sharing) (*sharing.Member, error) {
+	pdoc, err := middlewares.GetPermission(c)
+	if err != nil || pdoc.Type != permission.TypeShareInteract {
+		return nil, nil
+	}
+	token := middlewares.GetRequestToken(c)
+	member, err := s.FindMemberByInteractCode(inst, token)
+	if err != nil {
+		return nil, wrapErrors(err)
+	}
+	if member == nil {
+		return nil, jsonapi.Forbidden(errors.New("not a member of this sharing"))
+	}
+	return member, nil
+}
+
+// guardSharedDriveRouteForMember authorizes a request reaching the owner of
+// a shared drive against the effective access of the calling member on the
+// target file or folder. Only drive tokens (share-interact) are constrained
+// this way: the owner's own tokens have full rights, and public secret
+// routes carry no member identity (AllowVFS in the handlers governs them).
+// The member is resolved once by proxy and read from the context.
+func guardSharedDriveRouteForMember(c echo.Context, inst *instance.Instance, s *sharing.Sharing) error {
+	member := GetSharedDriveMember(c)
+	if member == nil {
+		return nil
+	}
+
+	method := c.Request().Method
+	if method == http.MethodHead {
+		method = http.MethodGet
+	}
+	verb := permission.Verb(method)
+	reqPath := c.Request().URL.Path
+	fileID := c.Param("file-id")
+
+	// Share-by-link routes keep their own authorization layer. Match the
+	// registered route pattern, not the raw URL, so a future route whose
+	// path contains "/permissions" cannot silently bypass this guard.
+	if strings.HasPrefix(c.Path(), "/sharings/drives/:id/permissions") {
+		return nil
+	}
+	// Trashed files are outside every sharing scope: the effective access
+	// resolver cannot see them. Restore and destroy are authorized against
+	// the effective write access on the folder the file would be restored
+	// to (which is also where destroy removes it from, logically).
+	if strings.Contains(reqPath, "/trash/") {
+		if shouldCheck, requireWrite := sharedDrivePermissionCheck(method, reqPath); !shouldCheck || !requireWrite {
+			return nil
+		}
+		if err := checkTrashEffectiveAccess(inst, fileID, member); err != nil {
+			return err
+		}
+		// The guard has authorized the request: the handlers skip their VFS
+		// permission check for share-interact tokens (it cannot succeed on a
+		// trashed file, which has lost its referenced_by and whose path is
+		// outside the sharing rules). See files.driveMemberAuthorized.
+		return nil
+	}
+
+	// Write routes without a file target create content at the drive root:
+	// they require effective write on the root folder.
+	//
+	// ponytail: POST /upload/metadata is checked against the drive root,
+	// not the dir_id declared in its body; resolve the body dir_id when
+	// limited_access lands.
+	if fileID == "" {
+		if shouldCheck, requireWrite := sharedDrivePermissionCheck(method, reqPath); !shouldCheck || !requireWrite {
+			return nil
+		}
+		rootID, err := s.DriveRootID()
+		if err != nil {
+			return wrapErrors(err)
+		}
+		return checkEffectiveAccessForMember(inst, rootID, permission.POST, member)
+	}
+
+	// Copy needs effective read on the source and effective write on the
+	// destination folder. File-root drives do not support copy: let the
+	// handler answer 422.
+	if method == http.MethodPost && strings.HasSuffix(reqPath, "/copy") {
+		if s.HasFileDriveRoot() {
+			return nil
+		}
+		if err := checkEffectiveAccessForMember(inst, fileID, permission.GET, member); err != nil {
+			return err
+		}
+		destID := c.QueryParam("DirID")
+		if destID == "" {
+			file, err := inst.VFS().FileByID(fileID)
+			if err != nil {
+				return files.WrapVfsError(err)
+			}
+			destID = file.DirID
+		}
+		return checkEffectiveAccessForMember(inst, destID, permission.POST, member)
+	}
+
+	return checkEffectiveAccessForMember(inst, fileID, verb, member)
+}
+
+// checkEffectiveAccessForMember checks that the given sharing member has the
+// effective access required by verb on the target file or folder.
+func checkEffectiveAccessForMember(inst *instance.Instance, targetID string, verb permission.Verb, member *sharing.Member) error {
+	ea, err := authorizeDriveTarget(inst, member, targetID)
+	if err != nil {
+		return err
+	}
+	if !ea.Can(verb) {
+		return jsonapi.Forbidden(errors.New("insufficient access on the target file or folder"))
+	}
+	return nil
+}
+
+// checkTrashEffectiveAccess authorizes a restore or destroy of a trashed
+// file against the member's effective write access on the folder the file
+// would be restored to. A trashed file is outside every sharing scope, so
+// the check walks up from the restore folder to the first existing ancestor
+// (the restore recreates the missing hierarchy under it via MkdirAll) and
+// resolves the effective access there. A file whose restore folder is in no
+// sharing scope (e.g. trashed from outside any drive) is rejected.
+func checkTrashEffectiveAccess(inst *instance.Instance, fileID string, member *sharing.Member) error {
+	fs := inst.VFS()
+	dir, file, err := fs.DirOrFileByID(fileID)
+	if err != nil {
+		return files.WrapVfsError(err)
+	}
+
+	var restorePath, docPath string
+	if dir != nil {
+		restorePath = dir.RestorePath
+		docPath = dir.Fullpath
+	} else {
+		restorePath = file.RestorePath
+		docPath, err = file.Path(fs)
+		if err != nil {
+			return files.WrapVfsError(err)
+		}
+	}
+
+	// A file trashed with its parent hierarchy has no restore path of its
+	// own: resolve it from the trashed root folder, like getRestoreDir does.
+	if restorePath == "" {
+		rel := strings.TrimPrefix(docPath, vfs.TrashDirName+"/")
+		split := strings.Index(rel, "/")
+		if split < 0 {
+			// ponytail: no resolvable restore root; getRestoreDir would fall
+			// back to the instance root, which is in no sharing scope.
+			return jsonapi.Forbidden(errors.New("insufficient access on the target file or folder"))
+		}
+		root, err := fs.DirByPath(vfs.TrashDirName + "/" + rel[:split])
+		if err != nil {
+			return files.WrapVfsError(err)
+		}
+		rest := path.Dir(rel[split+1:])
+		restorePath = path.Join(root.RestorePath, root.DocName, rest)
+	}
+	// The restore path is the folder the file or directory is restored into
+	// (and the directory itself is recreated inside it): that is where the
+	// write happens.
+	parentPath := restorePath
+
+	// Walk up to the first existing ancestor: the restore recreates the
+	// missing hierarchy under it, so that ancestor is where the write
+	// actually happens.
+	for {
+		ancestor, err := fs.DirByPath(parentPath)
+		if err == nil {
+			return checkEffectiveAccessForMember(inst, ancestor.ID(), permission.POST, member)
+		}
+		if !os.IsNotExist(err) {
+			return files.WrapVfsError(err)
+		}
+		next := path.Dir(parentPath)
+		if next == parentPath {
+			return jsonapi.Forbidden(errors.New("insufficient access on the target file or folder"))
+		}
+		parentPath = next
 	}
 }
 

--- a/web/sharings/drives.go
+++ b/web/sharings/drives.go
@@ -1,7 +1,10 @@
 package sharings
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -577,6 +580,34 @@ func ThumbnailHandler(c echo.Context, inst *instance.Instance, s *sharing.Sharin
 func FileDownloadCreateHandler(c echo.Context, inst *instance.Instance, s *sharing.Sharing) error {
 	// TODO: The route contract can be broader than the drive root, especially
 	// for owner requests. To fix it, we need explicit shared-drive scope check here.
+	//
+	// The guard cannot help here: the target lives in the query string, not
+	// in the route. Check the member's effective read on it before minting
+	// the temporary link.
+	// Resolve the target with the same precedence as files.FileDownload
+	// (Path -> Id -> VersionId), else a request with both Id and Path would
+	// be validated on the wrong file and mint a link for the other one.
+	var id string
+	if p := c.QueryParam("Path"); p != "" {
+		_, file, err := inst.VFS().DirOrFileByPath(p)
+		if err != nil {
+			return files.WrapVfsError(err)
+		}
+		if file == nil {
+			return jsonapi.NotFound(errors.New("shared drive target not found"))
+		}
+		id = file.DocID
+	} else if id = c.QueryParam("Id"); id == "" {
+		if versionID := c.QueryParam("VersionId"); versionID != "" {
+			id = strings.Split(versionID, "/")[0]
+		}
+	}
+	if id == "" {
+		return jsonapi.BadRequest(errors.New("missing file target"))
+	}
+	if err := checkDriveMemberRead(c, inst, id); err != nil {
+		return err
+	}
 	return files.FileDownload(c, s)
 }
 
@@ -590,6 +621,65 @@ func FileDownloadHandler(c echo.Context, inst *instance.Instance, s *sharing.Sha
 func ArchiveDownloadCreateHandler(c echo.Context, inst *instance.Instance, s *sharing.Sharing) error {
 	if err := ensureDirectoryBackedSharedDrive(s); err != nil {
 		return err
+	}
+	// The guard cannot help here: the targets live in the request body. Check
+	// the member's effective read on every target before minting the link.
+	// files.ArchiveDownload binds the body again, so restore it.
+	if GetSharedDriveMember(c) != nil {
+		body, err := io.ReadAll(c.Request().Body)
+		if err != nil {
+			return jsonapi.BadJSON()
+		}
+		c.Request().Body = io.NopCloser(bytes.NewReader(body))
+		var payload struct {
+			Data struct {
+				Attributes struct {
+					IDs   []string   `json:"ids"`
+					Files []string   `json:"files"`
+					Pages []vfs.Page `json:"pages"`
+				} `json:"attributes"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return jsonapi.BadJSON()
+		}
+		for _, id := range payload.Data.Attributes.IDs {
+			if err := checkDriveMemberRead(c, inst, id); err != nil {
+				return err
+			}
+		}
+		for _, p := range payload.Data.Attributes.Pages {
+			if err := checkDriveMemberRead(c, inst, p.ID); err != nil {
+				return err
+			}
+		}
+		for _, f := range payload.Data.Attributes.Files {
+			// The / and /files keys cover the whole account, outside any
+			// drive scope; the VFS check in files.ArchiveDownload governs
+			// them. The /trash key has no resolvable identifiers.
+			// ponytail: members with access to a single nested folder can
+			// still archive it via ids, files outside their scope get a 404.
+			if f == "/" || f == "/files" {
+				continue
+			}
+			if f == "/trash" {
+				return jsonapi.Forbidden(errors.New("cannot archive the trash"))
+			}
+			// files entries are paths, not ids: resolve the target first.
+			dir, file, err := inst.VFS().DirOrFileByPath(f)
+			if err != nil {
+				return files.WrapVfsError(err)
+			}
+			var targetID string
+			if dir != nil {
+				targetID = dir.DocID
+			} else {
+				targetID = file.DocID
+			}
+			if err := checkDriveMemberRead(c, inst, targetID); err != nil {
+				return err
+			}
+		}
 	}
 	return files.ArchiveDownload(c, s)
 }
@@ -768,11 +858,7 @@ func validateSharedDrivePermissionTargetID(
 	// The caller must be able to read the target. Drive tokens are checked
 	// against the member's effective access; other tokens keep the VFS
 	// permission check.
-	member, err := sharedDriveInteractMember(c, inst, s)
-	if err != nil {
-		return err
-	}
-	if member != nil {
+	if member := GetSharedDriveMember(c); member != nil {
 		if err := checkEffectiveAccessForMember(inst, fileID, permission.GET, member); err != nil {
 			return err
 		}

--- a/web/sharings/drives.go
+++ b/web/sharings/drives.go
@@ -287,6 +287,24 @@ func checkDriveMemberRead(c echo.Context, inst *instance.Instance, targetID stri
 	return err
 }
 
+// driveOpenReadOnly says whether an open route (note, office, editor) must be
+// forced read-only for the calling drive member: the interact token carries
+// ALL verbs, so the member's read-only restriction is enforced at the
+// application layer. It also requires effective read on the target. Returns
+// false for non-member tokens (owner, share-by-link): the VFS check in the
+// open handlers governs them.
+func driveOpenReadOnly(c echo.Context, inst *instance.Instance, fileID string) (bool, error) {
+	member := GetSharedDriveMember(c)
+	if member == nil {
+		return false, nil
+	}
+	ea, err := authorizeDriveTarget(inst, member, fileID)
+	if err != nil {
+		return false, err
+	}
+	return !ea.Can(permission.PUT), nil
+}
+
 // ReadMetadataFromPath allows to get file/dir information for a path.
 func ReadMetadataFromPath(c echo.Context, inst *instance.Instance, s *sharing.Sharing) error {
 	// Drive tokens are checked against the member's effective read access on
@@ -713,107 +731,39 @@ func GetShortcut(c echo.Context, inst *instance.Instance, s *sharing.Sharing) er
 }
 
 // OpenNoteURL returns the parameters to open a note inside a shared drive.
-func OpenNoteURL(c echo.Context) error {
-	inst := middlewares.GetInstance(c)
-	s, err := sharing.FindSharing(inst, c.Param("id"))
+// The recipient is proxied to the owner by proxy(); this handler only runs
+// on the owner.
+func OpenNoteURL(c echo.Context, inst *instance.Instance, s *sharing.Sharing) error {
+	forced, err := driveOpenReadOnly(c, inst, c.Param("file-id"))
 	if err != nil {
-		return wrapErrors(err)
-	}
-	if !s.Drive {
-		return jsonapi.NotFound(errors.New("not a drive"))
-	}
-	if s.Owner {
-		return notes.OpenNoteURL(c)
-	}
-
-	if err := middlewares.AllowWholeType(c, permission.GET, consts.Files); err != nil {
 		return err
 	}
-
-	fileID := c.Param("file-id")
-	fileOpener := &sharing.FileOpener{
-		Inst:    inst,
-		Sharing: s,
-		File:    &vfs.FileDoc{DocID: fileID},
-	}
-	open := &sharing.NoteOpener{FileOpener: fileOpener}
-
-	doc, err := open.GetResult(-1, false)
-	if err != nil {
-		return wrapErrors(err)
-	}
-
-	return jsonapi.Data(c, http.StatusOK, doc, nil)
+	readOnly := forced || c.QueryParam("ReadOnly") == "true"
+	return notes.OpenNoteURLWithReadOnly(c, readOnly)
 }
 
 // OpenOffice returns the parameter to open an office document inside a shared
-// drive.
-func OpenOffice(c echo.Context) error {
-	inst := middlewares.GetInstance(c)
-	s, err := sharing.FindSharing(inst, c.Param("id"))
+// drive. The recipient is proxied to the owner by proxy(); this handler only
+// runs on the owner.
+func OpenOffice(c echo.Context, inst *instance.Instance, s *sharing.Sharing) error {
+	forced, err := driveOpenReadOnly(c, inst, c.Param("file-id"))
 	if err != nil {
-		return wrapErrors(err)
-	}
-	if !s.Drive {
-		return jsonapi.NotFound(errors.New("not a drive"))
-	}
-	if s.Owner {
-		return office.Open(c)
-	}
-
-	if err := middlewares.AllowWholeType(c, permission.GET, consts.Files); err != nil {
 		return err
 	}
-
-	fileID := c.Param("file-id")
-	fileOpener := &sharing.FileOpener{
-		Inst:    inst,
-		Sharing: s,
-		File:    &vfs.FileDoc{DocID: fileID},
-	}
-	open := &sharing.OfficeOpener{FileOpener: fileOpener}
-
-	doc, err := open.GetResult(-1, false)
-	if err != nil {
-		return wrapErrors(err)
-	}
-
-	return jsonapi.Data(c, http.StatusOK, doc, nil)
+	readOnly := forced || c.QueryParam("ReadOnly") == "true"
+	return office.OpenWithReadOnly(c, readOnly)
 }
 
 // OpenEditor returns the parameters to open a file with an editor inside a
-// shared drive.
-func OpenEditor(c echo.Context) error {
-	inst := middlewares.GetInstance(c)
-	s, err := sharing.FindSharing(inst, c.Param("id"))
+// shared drive. The recipient is proxied to the owner by proxy(); this
+// handler only runs on the owner.
+func OpenEditor(c echo.Context, inst *instance.Instance, s *sharing.Sharing) error {
+	forced, err := driveOpenReadOnly(c, inst, c.Param("file-id"))
 	if err != nil {
-		return wrapErrors(err)
-	}
-	if !s.Drive {
-		return jsonapi.NotFound(errors.New("not a drive"))
-	}
-	if s.Owner {
-		return editor.OpenURL(c)
-	}
-
-	if err := middlewares.AllowWholeType(c, permission.GET, consts.Files); err != nil {
 		return err
 	}
-
-	fileID := c.Param("file-id")
-	fileOpener := &sharing.FileOpener{
-		Inst:    inst,
-		Sharing: s,
-		File:    &vfs.FileDoc{DocID: fileID},
-	}
-	open := &sharing.EditorOpener{FileOpener: fileOpener}
-
-	doc, err := open.GetResult(-1, false)
-	if err != nil {
-		return wrapErrors(err)
-	}
-
-	return jsonapi.Data(c, http.StatusOK, doc, nil)
+	readOnly := forced || c.QueryParam("ReadOnly") == "true"
+	return editor.OpenURLWithReadOnly(c, readOnly)
 }
 
 // CreateSharedDriveShareByLinkHandler creates a share-by-link permission for a file in a shared drive.
@@ -1518,10 +1468,10 @@ func drivesRoutes(router *echo.Group) {
 	drive.DELETE("/:file-id", proxy(TrashHandler, true))
 
 	drive.POST("/notes", proxy(CreateNote, true))
-	drive.GET("/notes/:file-id/open", OpenNoteURL)
+	drive.GET("/notes/:file-id/open", proxy(OpenNoteURL, true))
 	drive.GET("/recipients/:file-id", proxy(GetDriveEffectiveRecipients, true))
-	drive.GET("/office/:file-id/open", OpenOffice)
-	drive.GET("/editor/:file-id/open", OpenEditor)
+	drive.GET("/office/:file-id/open", proxy(OpenOffice, true))
+	drive.GET("/editor/:file-id/open", proxy(OpenEditor, true))
 
 	drive.GET("/shortcuts/:file-id", proxy(GetShortcut, true))
 
@@ -1689,6 +1639,12 @@ func guardSharedDriveRouteForMember(c echo.Context, inst *instance.Instance, s *
 	// registered route pattern, not the raw URL, so a future route whose
 	// path contains "/permissions" cannot silently bypass this guard.
 	if strings.HasPrefix(c.Path(), "/sharings/drives/:id/permissions") {
+		return nil
+	}
+	// Open routes (note, office, editor) are checked in the handler by
+	// driveOpenReadOnly: the guard's 403 would leak the existence of a
+	// target outside every scope, where the handler answers 404.
+	if strings.HasSuffix(c.Path(), "/open") {
 		return nil
 	}
 	// Trashed files are outside every sharing scope: the effective access

--- a/web/sharings/drives_effective_access_security_test.go
+++ b/web/sharings/drives_effective_access_security_test.go
@@ -1,0 +1,31 @@
+package sharings_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSharedDrivePendingNestedMemberDoesNotGrantEffectiveWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, _, eD := env.createClients(t)
+
+	// Dave accepted read-only D1, but has not accepted the writable nested D2.
+	d1ID, d1RootID, _ := createSharedDrive(t, DriveCreationMethodFromFolder,
+		env.acme, env.acmeToken, env.tsA.URL, "Pending member D1", "d1",
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: true}})
+	writableDirID := createDirectory(t, eA, d1RootID, "Pending writable", env.acmeToken)
+	nestedFileID := createFile(t, eA, writableDirID, "pending.txt", env.acmeToken)
+	createDriveOnFolder(t, eA, env.acme, writableDirID, env.acmeToken,
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: false}})
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d1ID)
+
+	eD.PATCH("/sharings/drives/"+d1ID+"/"+nestedFileID).
+		WithHeader("Authorization", "Bearer "+env.daveToken).
+		WithHeader("Content-Type", jsonAPIContentType).
+		WithBytes([]byte(`{"data":{"type":"io.cozy.files","id":"` + nestedFileID + `","attributes":{"name":"must-not-change.txt"}}}`)).
+		Expect().Status(http.StatusForbidden)
+}

--- a/web/sharings/drives_effective_access_security_test.go
+++ b/web/sharings/drives_effective_access_security_test.go
@@ -3,7 +3,69 @@ package sharings_test
 import (
 	"net/http"
 	"testing"
+
+	"github.com/gavv/httpexpect/v2"
 )
+
+func TestSharedDriveWritableOpenSharecodeCannotWriteOutsideEffectiveScope(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, _, eD := env.createClients(t)
+
+	// Dave can read D1 and write only inside its nested D2 scope.
+	d1ID, d1RootID, _ := createSharedDrive(t, DriveCreationMethodFromFolder,
+		env.acme, env.acmeToken, env.tsA.URL, "Open scope D1", "d1",
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: true}})
+	writableDirID := createDirectory(t, eA, d1RootID, "Writable", env.acmeToken)
+	rootOnlyFileID := createFile(t, eA, d1RootID, "read-only.txt", env.acmeToken)
+	d2ID := createDriveOnFolder(t, eA, env.acme, writableDirID, env.acmeToken,
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: false}})
+
+	noteID := eA.POST("/sharings/drives/"+d1ID+"/notes").
+		WithHeader("Authorization", "Bearer "+env.acmeToken).
+		WithHeader("Content-Type", "application/json").
+		WithBytes([]byte(`{
+			"data": {
+				"type": "io.cozy.notes.documents",
+				"attributes": {
+					"title": "Writable note",
+					"dir_id": "` + writableDirID + `",
+					"schema": {
+						"nodes": [
+							["doc", {"content": "block+"}],
+							["paragraph", {"content": "inline*", "group": "block"}],
+							["text", {"group": "inline"}]
+						],
+						"marks": [],
+						"topNode": "doc"
+					}
+				}
+			}
+		}`)).
+		Expect().Status(http.StatusCreated).
+		JSON(httpexpect.ContentOpts{MediaType: jsonAPIContentType}).
+		Object().Path("$.data.id").String().NotEmpty().Raw()
+
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d1ID)
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d2ID)
+
+	sharecode := eD.GET("/sharings/drives/"+d1ID+"/notes/"+noteID+"/open").
+		WithHeader("Authorization", "Bearer "+env.daveToken).
+		Expect().Status(http.StatusOK).
+		JSON(httpexpect.ContentOpts{MediaType: jsonAPIContentType}).
+		Object().Path("$.data.attributes.sharecode").String().NotEmpty().Raw()
+
+	// The writable sharecode for the nested note must not grant write access
+	// to a sibling where Dave only has D1's read-only access.
+	eA.PUT("/files/"+rootOnlyFileID).
+		WithHeader("Authorization", "Bearer "+sharecode).
+		WithHeader("Content-Type", "text/plain").
+		WithBytes([]byte("must not be writable")).
+		Expect().Status(http.StatusForbidden)
+}
 
 func TestSharedDrivePendingNestedMemberDoesNotGrantEffectiveWrite(t *testing.T) {
 	if testing.Short() {

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -4905,6 +4905,17 @@ func TestSharedDriveNotes(t *testing.T) {
 		}
 	})
 
+	t.Run("OpenNoteWithUnknownIDFromSharedDrive", func(t *testing.T) {
+		_, eB, _ := env.createClients(t)
+
+		// The member token carries ALL verbs, so the guard is what rejects
+		// the unknown target: effective-access resolution hits os.ErrNotExist
+		// and must answer 404, not a wrapped internal error.
+		eB.GET("/sharings/drives/"+env.firstSharingID+"/notes/unknown-note-id/open").
+			WithHeader("Authorization", "Bearer "+env.bettyToken).
+			Expect().Status(http.StatusNotFound)
+	})
+
 	t.Run("OpenFileWithEditorFromSharedDrive", func(t *testing.T) {
 		eA, eB, _ := env.createClients(t)
 
@@ -6285,5 +6296,187 @@ func TestSharedDriveDownloadLinksEffectiveAccess(t *testing.T) {
 			WithQuery("Id", outsideFileID).
 			WithHeader("Authorization", "Bearer "+env.acmeToken).
 			Expect().Status(200)
+	})
+}
+
+func TestSharedDriveOpenRoutesEffectiveAccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, _, eD := env.createClients(t)
+
+	// D1: Dave is a read-only member of the whole drive.
+	d1ID, d1RootID, _ := createSharedDrive(t, DriveCreationMethodFromFolder,
+		env.acme, env.acmeToken, env.tsA.URL, "Open D1", "d1",
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: true}})
+
+	// A note inside the drive, created by the owner.
+	noteObj := eA.POST("/sharings/drives/"+d1ID+"/notes").
+		WithHeader("Authorization", "Bearer "+env.acmeToken).
+		WithHeader("Content-Type", "application/json").
+		WithBytes([]byte(`{
+			"data": {
+				"type": "io.cozy.notes.documents",
+				"attributes": {
+					"title": "Drive Note",
+					"dir_id": "` + d1RootID + `",
+					"schema": {
+						"nodes": [
+							["doc", { "content": "block+" }],
+							["paragraph", { "content": "inline*", "group": "block" }],
+							["text", { "group": "inline" }]
+						],
+						"marks": [],
+						"topNode": "doc"
+					}
+				}
+			}
+		}`)).
+		Expect().Status(201).
+		JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+		Object()
+	noteID := noteObj.Value("data").Object().Value("id").String().Raw()
+
+	// A file outside every drive: Dave has no effective access to it.
+	outsideDirID := createRootDirectory(t, eA, "OutsideOpen", env.acmeToken)
+	outsideFileID := createFile(t, eA, outsideDirID, "outside.txt", env.acmeToken)
+
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d1ID)
+
+	t.Run("OpenNoteInScopeAllowed", func(t *testing.T) {
+		obj := eD.GET("/sharings/drives/"+d1ID+"/notes/"+noteID+"/open").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+		attrs := obj.Path("$.data.attributes").Object()
+
+		// The file must be opened on the owner's instance, not the recipient's.
+		attrs.Value("instance").String().IsEqual(env.acme.Domain)
+
+		// Dave is read-only on the whole drive: the opening must have been
+		// forced read-only, i.e. the returned sharecode must resolve to a
+		// share-preview permission (read-only), not a share-interact one.
+		sharecode := attrs.Value("sharecode").String().NotEmpty().Raw()
+		permObj := eA.GET("/permissions/self").
+			WithHeader("Authorization", "Bearer "+sharecode).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+		permObj.Path("$.data.attributes.type").String().IsEqual("share-preview")
+	})
+
+	t.Run("OpenNoteOutOfScopeNotFound", func(t *testing.T) {
+		eD.GET("/sharings/drives/"+d1ID+"/notes/"+outsideFileID+"/open").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(404)
+	})
+
+	t.Run("OpenOfficeOutOfScopeNotFound", func(t *testing.T) {
+		eD.GET("/sharings/drives/"+d1ID+"/office/"+outsideFileID+"/open").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(404)
+	})
+
+	t.Run("OpenEditorOutOfScopeNotFound", func(t *testing.T) {
+		eD.GET("/sharings/drives/"+d1ID+"/editor/"+outsideFileID+"/open").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(404)
+	})
+
+	t.Run("OwnerTokenUnrestricted", func(t *testing.T) {
+		eA.GET("/sharings/drives/"+d1ID+"/notes/"+noteID+"/open").
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			Expect().Status(200)
+	})
+}
+
+func TestSharedDriveOpenReadWriteByRecipient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, _, eD := env.createClients(t)
+
+	// D1: Dave is a read-only member of the whole drive.
+	d1ID, d1RootID, _ := createSharedDrive(t, DriveCreationMethodFromFolder,
+		env.acme, env.acmeToken, env.tsA.URL, "RW Open D1", "d1",
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: true}})
+
+	// D2: Dave has write access on the nested Writable folder.
+	writableDirID := createDirectory(t, eA, d1RootID, "Writable", env.acmeToken)
+	d2ID := createDriveOnFolder(t, eA, env.acme, writableDirID, env.acmeToken,
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: false}})
+
+	// The owner creates one note in the writable folder and one at the drive
+	// root.
+	noteSchema := `{
+		"nodes": [
+			["doc", { "content": "block+" }],
+			["paragraph", { "content": "inline*", "group": "block" }],
+			["text", { "group": "inline" }]
+		],
+		"marks": [],
+		"topNode": "doc"
+	}`
+	createNote := func(dirID, title string) string {
+		return eA.POST("/sharings/drives/"+d1ID+"/notes").
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(`{
+				"data": {
+					"type": "io.cozy.notes.documents",
+					"attributes": {
+						"title": "` + title + `",
+						"dir_id": "` + dirID + `",
+						"schema": ` + noteSchema + `
+					}
+				}
+			}`)).
+			Expect().Status(201).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object().Path("$.data.id").String().NotEmpty().Raw()
+	}
+	noteInWritableID := createNote(writableDirID, "Writable Note")
+
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d1ID)
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d2ID)
+
+	sharecodeType := func(path string, readOnlyQuery bool) string {
+		req := eD.GET(path)
+		if readOnlyQuery {
+			req = req.WithQuery("ReadOnly", "true")
+		}
+		obj := req.
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+		attrs := obj.Path("$.data.attributes").Object()
+		attrs.Value("instance").String().IsEqual(env.acme.Domain)
+		sharecode := attrs.Value("sharecode").String().NotEmpty().Raw()
+		permObj := eA.GET("/permissions/self").
+			WithHeader("Authorization", "Bearer "+sharecode).
+			Expect().Status(200).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object()
+		return permObj.Path("$.data.attributes.type").String().Raw()
+	}
+
+	t.Run("OpenNoteInWritableFolderReadWrite", func(t *testing.T) {
+		codeType := sharecodeType("/sharings/drives/"+d1ID+"/notes/"+noteInWritableID+"/open", false)
+		if codeType != "share-interact" {
+			t.Errorf("expected share-interact sharecode, got %s", codeType)
+		}
+	})
+
+	t.Run("ExplicitReadOnlyRespected", func(t *testing.T) {
+		codeType := sharecodeType("/sharings/drives/"+d1ID+"/notes/"+noteInWritableID+"/open", true)
+		if codeType != "share-preview" {
+			t.Errorf("expected share-preview sharecode, got %s", codeType)
+		}
 	})
 }

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -6174,3 +6174,116 @@ func TestSharedDriveEffectiveAccessOnMetadataByPath(t *testing.T) {
 			Expect().Status(404)
 	})
 }
+
+func TestSharedDriveDownloadLinksEffectiveAccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, _, eD := env.createClients(t)
+
+	// D1: Dave is a read-only member of the whole drive.
+	d1ID, d1RootID, _ := createSharedDrive(t, DriveCreationMethodFromFolder,
+		env.acme, env.acmeToken, env.tsA.URL, "Downloads D1", "d1",
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: true}})
+
+	inScopeFileID := createFile(t, eA, d1RootID, "inside.txt", env.acmeToken)
+
+	// A file outside every drive: Dave has no effective access to it.
+	outsideDirID := createRootDirectory(t, eA, "OutsideDrive", env.acmeToken)
+	outsideFileID := createFile(t, eA, outsideDirID, "outside.txt", env.acmeToken)
+
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d1ID)
+
+	t.Run("DownloadInScopeAllowed", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/downloads").
+			WithQuery("Id", inScopeFileID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(200)
+	})
+
+	t.Run("DownloadOutOfScopeNotFound", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/downloads").
+			WithQuery("Id", outsideFileID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(404)
+	})
+
+	t.Run("ArchiveInScopeAllowed", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/archive").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithBytes([]byte(`{"data":{"type":"io.cozy.archives","attributes":{"ids":["` + inScopeFileID + `"]}}}`)).
+			Expect().Status(200)
+	})
+
+	t.Run("ArchiveWithOutOfScopeNotFound", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/archive").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithBytes([]byte(`{"data":{"type":"io.cozy.archives","attributes":{"ids":["` + inScopeFileID + `","` + outsideFileID + `"]}}}`)).
+			Expect().Status(404)
+	})
+
+	t.Run("ArchiveByPathInScopeAllowed", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/archive").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithBytes([]byte(`{"data":{"type":"io.cozy.archives","attributes":{"files":["/Downloads D1/inside.txt"]}}}`)).
+			Expect().Status(200)
+	})
+
+	t.Run("ArchiveByPathOutOfScopeNotFound", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/archive").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithBytes([]byte(`{"data":{"type":"io.cozy.archives","attributes":{"files":["/OutsideDrive/outside.txt"]}}}`)).
+			Expect().Status(404)
+	})
+
+	t.Run("ArchiveByFolderPathAllowed", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/archive").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithBytes([]byte(`{"data":{"type":"io.cozy.archives","attributes":{"files":["/Downloads D1"]}}}`)).
+			Expect().Status(200)
+	})
+
+	t.Run("DownloadIdAndPathPrefersPath", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/downloads").
+			WithQuery("Id", inScopeFileID).
+			WithQuery("Path", "/OutsideDrive/outside.txt").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(404)
+
+		eD.POST("/sharings/drives/"+d1ID+"/downloads").
+			WithQuery("Id", outsideFileID).
+			WithQuery("Path", "/Downloads D1/inside.txt").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(200)
+	})
+
+	t.Run("ArchiveWithPageOutOfScopeNotFound", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/archive").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithBytes([]byte(`{"data":{"type":"io.cozy.archives","attributes":{"pages":[{"id":"` + outsideFileID + `","page":1}]}}}`)).
+			Expect().Status(404)
+	})
+
+	t.Run("ArchiveWithPageInScopeAllowed", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/archive").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/vnd.api+json").
+			WithBytes([]byte(`{"data":{"type":"io.cozy.archives","attributes":{"pages":[{"id":"` + inScopeFileID + `","page":1}]}}}`)).
+			Expect().Status(200)
+	})
+
+	t.Run("OwnerTokenUnrestricted", func(t *testing.T) {
+		eA.POST("/sharings/drives/"+d1ID+"/downloads").
+			WithQuery("Id", outsideFileID).
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			Expect().Status(200)
+	})
+}

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -5987,6 +5987,56 @@ func TestSharedDriveEffectiveAccessOnTargetedRoutes(t *testing.T) {
 	})
 }
 
+func TestSharedDriveEffectiveAccessOnRootWriteRoutes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, _, eD := env.createClients(t)
+
+	// D1: Dave has write access on the whole drive.
+	d1ID, d1RootID, _ := createSharedDrive(t, DriveCreationMethodFromFolder,
+		env.acme, env.acmeToken, env.tsA.URL, "Root Write D1", "d1",
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: false}})
+
+	subDirID := createDirectory(t, eA, d1RootID, "Sub", env.acmeToken)
+
+	// D2: nested drive on Sub, Dave is read-only there, but keeps write
+	// access on its root through the ancestor D1 scope.
+	d2ID := createDriveOnFolder(t, eA, env.acme, subDirID, env.acmeToken,
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: true}})
+
+	// D3: independent drive where Dave is read-only everywhere.
+	d3ID, d3RootID, _ := createSharedDrive(t, DriveCreationMethodFromFolder,
+		env.acme, env.acmeToken, env.tsA.URL, "Root Write D3", "d3",
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: true}})
+
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d1ID)
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d2ID)
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d3ID)
+
+	notePayload := func(dirID string) string {
+		return `{"data":{"type":"io.cozy.notes.documents","attributes":{"title":"N","dir_id":"` + dirID + `","schema":{"nodes":[["doc",{"content":"block+"}],["paragraph",{"content":"inline*","group":"block"}],["text",{"group":"inline"}]],"marks":[],"topNode":"doc"}}}}`
+	}
+
+	t.Run("RootWriteAllowedViaAncestorScope", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d2ID+"/notes").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(notePayload(subDirID))).
+			Expect().Status(201)
+	})
+
+	t.Run("RootWriteDeniedForReadOnlyMember", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d3ID+"/notes").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(notePayload(d3RootID))).
+			Expect().Status(403)
+	})
+}
+
 func TestSharedDriveEffectiveAccessOnMoveDestination(t *testing.T) {
 	if testing.Short() {
 		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -3844,11 +3844,11 @@ func TestFileRootSharedDriveReadRoutes(t *testing.T) {
 
 		eB.GET("/sharings/drives/"+sharingID+"/"+unrelatedFileID).
 			WithHeader("Authorization", "Bearer "+env.bettyToken).
-			Expect().Status(403)
+			Expect().Status(404)
 
 		eB.GET("/sharings/drives/"+sharingID+"/download/"+unrelatedFileID).
 			WithHeader("Authorization", "Bearer "+env.bettyToken).
-			Expect().Status(403)
+			Expect().Status(404)
 	})
 
 	t.Run("OpenNoteRootFile", func(t *testing.T) {
@@ -4471,7 +4471,7 @@ func TestSharedDriveFileCopy(t *testing.T) {
 			WithHeader("Content-Type", "text/plain").
 			WithHeader("Authorization", "Bearer "+env.bettyToken).
 			WithBytes([]byte("")).
-			Expect().Status(403)
+			Expect().Status(404)
 	})
 }
 
@@ -4629,7 +4629,7 @@ func TestSharedDriveMetadata(t *testing.T) {
 					}
 				}
 			}`)).
-			Expect().Status(403)
+			Expect().Status(404)
 	})
 
 	t.Run("RenameFile", func(t *testing.T) {
@@ -5873,4 +5873,254 @@ func addContactToExistingGroup(t *testing.T, inst *instance.Instance, c *contact
 		},
 	}
 	require.NoError(t, couchdb.UpdateDoc(inst, c))
+}
+
+// createDriveOnFolder creates a shared drive on an existing folder (e.g. a
+// folder nested inside another shared drive) and returns the sharing ID.
+func createDriveOnFolder(
+	t *testing.T,
+	e *httpexpect.Expect,
+	inst *instance.Instance,
+	folderID, token string,
+	recipients []RecipientInfo,
+) string {
+	t.Helper()
+
+	var rwRefs, roRefs []map[string]interface{}
+	for _, r := range recipients {
+		c := createContact(t, inst, r.Name, r.Email)
+		ref := map[string]interface{}{"id": c.ID(), "type": consts.Contacts}
+		if r.ReadOnly {
+			roRefs = append(roRefs, ref)
+		} else {
+			rwRefs = append(rwRefs, ref)
+		}
+	}
+
+	obj := e.POST("/sharings/drives").
+		WithHeader("Authorization", "Bearer "+token).
+		WithHeader("Content-Type", jsonAPIContentType).
+		WithBytes(mustJSON(t, map[string]interface{}{
+			"data": map[string]interface{}{
+				"type": consts.Sharings,
+				"attributes": map[string]interface{}{
+					"description": "nested drive",
+					"folder_id":   folderID,
+				},
+				"relationships": map[string]interface{}{
+					"recipients":           map[string]interface{}{"data": rwRefs},
+					"read_only_recipients": map[string]interface{}{"data": roRefs},
+				},
+			},
+		})).
+		Expect().Status(201).
+		JSON(httpexpect.ContentOpts{MediaType: jsonAPIContentType}).
+		Object()
+
+	return obj.Value("data").Object().Value("id").String().NotEmpty().Raw()
+}
+
+func TestSharedDriveEffectiveAccessOnTargetedRoutes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, _, eD := env.createClients(t)
+
+	// D1: Dave is a read-only member of the whole drive.
+	d1ID, d1RootID, _ := createSharedDrive(t, DriveCreationMethodFromFolder,
+		env.acme, env.acmeToken, env.tsA.URL, "Effective Access D1", "d1",
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: true}})
+
+	writableDirID := createDirectory(t, eA, d1RootID, "Writable", env.acmeToken)
+	nestedFileID := createFile(t, eA, writableDirID, "nested.txt", env.acmeToken)
+	outsideFileID := createFile(t, eA, d1RootID, "outside.txt", env.acmeToken)
+
+	// D2: nested drive on the Writable folder, Dave has write access there.
+	d2ID := createDriveOnFolder(t, eA, env.acme, writableDirID, env.acmeToken,
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: false}})
+
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d1ID)
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d2ID)
+
+	renamePayload := func(id, name string) string {
+		return `{"data":{"type":"io.cozy.files","id":"` + id + `","attributes":{"name":"` + name + `"}}}`
+	}
+
+	t.Run("ReadAllowedViaRootScope", func(t *testing.T) {
+		eD.GET("/sharings/drives/"+d1ID+"/"+outsideFileID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(200)
+	})
+
+	t.Run("WriteDeniedWithReadOnlyRootScopeOnly", func(t *testing.T) {
+		eD.PATCH("/sharings/drives/"+d1ID+"/"+outsideFileID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(renamePayload(outsideFileID, "renamed.txt"))).
+			Expect().Status(403)
+	})
+
+	t.Run("WriteAllowedViaNestedScope", func(t *testing.T) {
+		eD.PATCH("/sharings/drives/"+d1ID+"/"+nestedFileID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(renamePayload(nestedFileID, "renamed-nested.txt"))).
+			Expect().Status(200)
+	})
+
+	t.Run("CopyToWritableDestination", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/"+outsideFileID+"/copy").
+			WithQuery("DirID", writableDirID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithBytes([]byte("")).
+			Expect().Status(201)
+	})
+
+	t.Run("CopyToReadOnlyDestinationDenied", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/"+nestedFileID+"/copy").
+			WithQuery("DirID", d1RootID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithBytes([]byte("")).
+			Expect().Status(403)
+	})
+}
+
+func TestSharedDriveEffectiveAccessOnMoveDestination(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, _, eD := env.createClients(t)
+
+	// D1: Dave is a read-only member of the whole drive.
+	d1ID, d1RootID, _ := createSharedDrive(t, DriveCreationMethodFromFolder,
+		env.acme, env.acmeToken, env.tsA.URL, "Move Dest D1", "d1",
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: true}})
+
+	writableDirID := createDirectory(t, eA, d1RootID, "Writable", env.acmeToken)
+	subDirID := createDirectory(t, eA, writableDirID, "Sub", env.acmeToken)
+	nestedFileID := createFile(t, eA, writableDirID, "nested.txt", env.acmeToken)
+
+	// D2: nested drive on the Writable folder, Dave has write access there.
+	d2ID := createDriveOnFolder(t, eA, env.acme, writableDirID, env.acmeToken,
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: false}})
+
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d1ID)
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d2ID)
+
+	movePayload := func(id, destID string) string {
+		return `{"data":{"type":"io.cozy.files","id":"` + id + `",` +
+			`"relationships":{"parent":{"data":{"type":"io.cozy.files","id":"` + destID + `"}}}}}`
+	}
+
+	t.Run("MoveToReadOnlyDestinationDenied", func(t *testing.T) {
+		eD.PATCH("/sharings/drives/"+d1ID+"/"+nestedFileID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(movePayload(nestedFileID, d1RootID))).
+			Expect().Status(403)
+	})
+
+	t.Run("MoveToWritableDestinationAllowed", func(t *testing.T) {
+		eD.PATCH("/sharings/drives/"+d1ID+"/"+nestedFileID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(movePayload(nestedFileID, subDirID))).
+			Expect().Status(200)
+	})
+
+	t.Run("RenameWithoutMoveAllowed", func(t *testing.T) {
+		eD.PATCH("/sharings/drives/"+d1ID+"/"+nestedFileID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(`{"data":{"type":"io.cozy.files","id":"` + nestedFileID + `","attributes":{"name":"renamed.txt"}}}`)).
+			Expect().Status(200)
+	})
+}
+
+func TestSharedDriveEffectiveAccessOnTrashRoutes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, _, eD := env.createClients(t)
+
+	// D1: Dave is a read-only member of the whole drive.
+	d1ID, d1RootID, _ := createSharedDrive(t, DriveCreationMethodFromFolder,
+		env.acme, env.acmeToken, env.tsA.URL, "Trash D1", "d1",
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: true}})
+
+	writableDirID := createDirectory(t, eA, d1RootID, "Writable", env.acmeToken)
+	nestedFileID := createFile(t, eA, writableDirID, "nested.txt", env.acmeToken)
+	outsideFileID := createFile(t, eA, d1RootID, "outside.txt", env.acmeToken)
+
+	// D2: nested drive on the Writable folder, Dave has write access there.
+	d2ID := createDriveOnFolder(t, eA, env.acme, writableDirID, env.acmeToken,
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: false}})
+
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d1ID)
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d2ID)
+
+	// The owner trashes one file from each location.
+	eA.DELETE("/files/"+nestedFileID).
+		WithHeader("Authorization", "Bearer "+env.acmeToken).
+		Expect().Status(200)
+	eA.DELETE("/files/"+outsideFileID).
+		WithHeader("Authorization", "Bearer "+env.acmeToken).
+		Expect().Status(200)
+
+	t.Run("RestoreFromWritableFolderAllowed", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/trash/"+nestedFileID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(200)
+	})
+
+	t.Run("RestoreFromReadOnlyFolderDenied", func(t *testing.T) {
+		eD.POST("/sharings/drives/"+d1ID+"/trash/"+outsideFileID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(403)
+	})
+
+	t.Run("DestroyFromReadOnlyFolderDenied", func(t *testing.T) {
+		eD.DELETE("/sharings/drives/"+d1ID+"/trash/"+outsideFileID).
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(403)
+	})
+}
+
+func TestSharedDriveEffectiveAccessOnMetadataByPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, _, eD := env.createClients(t)
+
+	d1ID, d1RootID, _ := createSharedDrive(t, DriveCreationMethodFromFolder,
+		env.acme, env.acmeToken, env.tsA.URL, "Metadata D1", "d1",
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: true}})
+
+	createFile(t, eA, d1RootID, "inside.txt", env.acmeToken)
+	outsideDirID := createRootDirectory(t, eA, "OutsideDrive", env.acmeToken)
+	createFile(t, eA, outsideDirID, "outside.txt", env.acmeToken)
+
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d1ID)
+
+	t.Run("PathInsideDriveAllowed", func(t *testing.T) {
+		eD.GET("/sharings/drives/"+d1ID+"/metadata").
+			WithQuery("Path", "/Metadata D1/inside.txt").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(200)
+	})
+
+	t.Run("PathOutsideDriveNotFound", func(t *testing.T) {
+		eD.GET("/sharings/drives/"+d1ID+"/metadata").
+			WithQuery("Path", "/OutsideDrive/outside.txt").
+			WithHeader("Authorization", "Bearer "+env.daveToken).
+			Expect().Status(404)
+	})
 }

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cozy/cozy-stack/web/errors"
 	"github.com/cozy/cozy-stack/web/files"
 	"github.com/cozy/cozy-stack/web/middlewares"
+	"github.com/cozy/cozy-stack/web/notes"
 	"github.com/cozy/cozy-stack/web/permissions"
 	"github.com/cozy/cozy-stack/web/sharings"
 	"github.com/cozy/cozy-stack/web/statik"
@@ -2517,4 +2518,112 @@ func TestReadOnlyHandlers(t *testing.T) {
 			WithHeader("Authorization", "Bearer "+ownerAppToken).
 			Expect().Status(422)
 	})
+}
+
+// TestOpenNoteInPreviewReturnsReadOnlySharecode checks that opening a note
+// from a sharing preview returns a read-only sharecode: the rules have no
+// sync (ReadOnlyRules is true) and the member is not flagged read-only, but
+// the previewer must not get a write-capable share-interact code.
+func TestOpenNoteInPreviewReturnsReadOnlySharecode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile(t)
+	build.BuildMode = build.ModeDev
+	config.GetConfig().Assets = "../../assets"
+	_ = web.LoadSupportedLocales()
+	testutils.NeedCouchdb(t)
+	render, _ := statik.NewDirRenderer("../../assets")
+	middlewares.BuildTemplates()
+
+	setup := testutils.NewSetup(t, t.Name()+"_alice")
+	aliceInstance := setup.GetTestInstance(&lifecycle.Options{
+		Email:      "alice@example.net",
+		PublicName: "Alice",
+	})
+	aliceAppToken := generateAppToken(aliceInstance, "testapp", consts.Files)
+	tsA := setup.GetTestServerMultipleRoutes(map[string]func(*echo.Group){
+		"/notes":       notes.Routes,
+		"/permissions": permissions.Routes,
+		"/sharings":    sharings.Routes,
+	})
+	tsA.Config.Handler.(*echo.Echo).Renderer = render
+	tsA.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
+	t.Cleanup(tsA.Close)
+
+	require.NoError(t, dynamic.InitDynamicAssetFS(config.FsURL().String()), "Could not init dynamic FS")
+	eA := httpexpect.Default(t, tsA.URL)
+
+	noteSchema := `{
+		"nodes": [
+			["doc", { "content": "block+" }],
+			["paragraph", { "content": "inline*", "group": "block" }],
+			["text", { "group": "inline" }]
+		],
+		"marks": [],
+		"topNode": "doc"
+	}`
+	noteObj := eA.POST("/notes").
+		WithHeader("Authorization", "Bearer "+aliceAppToken).
+		WithHeader("Content-Type", "application/json").
+		WithBytes([]byte(`{
+			"data": {
+				"type": "io.cozy.notes.documents",
+				"attributes": {
+					"title": "Preview Note",
+					"schema": ` + noteSchema + `
+				}
+			}
+		}`)).
+		Expect().Status(201).
+		JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+		Object()
+	noteID := noteObj.Value("data").Object().Value("id").String().NotEmpty().Raw()
+
+	bobContact := createContact(t, aliceInstance, "Bob", "bob@example.net")
+	sharingObj := eA.POST("/sharings/").
+		WithHeader("Authorization", "Bearer "+aliceAppToken).
+		WithHeader("Content-Type", "application/vnd.api+json").
+		WithBytes([]byte(`{
+		"data": {
+			"type": "` + consts.Sharings + `",
+			"attributes": {
+				"description": "preview of a note",
+				"preview_path": "/preview",
+				"rules": [{
+					"title": "note",
+					"doctype": "` + consts.Files + `",
+					"values": ["` + noteID + `"]
+				}]
+			},
+			"relationships": {
+				"recipients": {
+					"data": [{"id": "` + bobContact.ID() + `", "type": "` + bobContact.DocType() + `"}]
+				}
+			}
+		}
+	}`)).
+		Expect().Status(201).
+		JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+		Object()
+	sharingID := sharingObj.Value("data").Object().Value("id").String().NotEmpty().Raw()
+
+	preview, err := permission.GetForSharePreview(aliceInstance, sharingID)
+	require.NoError(t, err)
+	code, ok := preview.Codes["bob@example.net"]
+	require.True(t, ok, "no preview code for bob@example.net in %v", preview.Codes)
+
+	sharecode := eA.GET("/notes/"+noteID+"/open").
+		WithHeader("Authorization", "Bearer "+code).
+		Expect().Status(200).
+		JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+		Object().Path("$.data.attributes.sharecode").String().NotEmpty().Raw()
+
+	permObj := eA.GET("/permissions/self").
+		WithHeader("Authorization", "Bearer "+sharecode).
+		Expect().Status(200).
+		JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+		Object()
+	permObj.Path("$.data.attributes.type").String().IsEqual(permission.TypeSharePreview)
 }


### PR DESCRIPTION
  Closes #4842 

  Shared-drive file routes will authorize requests against the effective
  access of the calling member, resolved on the owner's instance where
  the drive content lives (recipients hold no local copies of drive
  files). `AccessResolver` gains `ResolveForMember`, which matches the
  member across sharings by email or instance host via the new
  `Sharing.MemberMatching`, so nested shared folder scopes combine as
  they already do for the instance-scoped `Resolve`.