### PR TITLE
feat(sharings): add shared drive version deletion

### DIFF
--- a/docs/shared-drives.md
+++ b/docs/shared-drives.md
@@ -1035,6 +1035,15 @@ Identical call to [`GET /files/download/:file-id/:version-id`](files.md#get-file
 but over a shared drive. See there for request and response examples, the only
 difference is the URL.
 
+### DELETE /sharings/drives/:id/:file-id/:version-id
+
+Permanently deletes an old version of a file. The caller must have write access
+to the shared drive.
+
+Identical call to [`DELETE /files/:file-id/:version-id`](files.md#delete-filesfile-idversion-id)
+but over a shared drive. See there for request and response examples, the only
+difference is the URL.
+
 ## Notes
 
 ### POST /sharings/drives/:id/notes

--- a/web/sharings/drives.go
+++ b/web/sharings/drives.go
@@ -299,6 +299,14 @@ func CopyVersionHandler(c echo.Context, inst *instance.Instance, s *sharing.Shar
 	return files.CopyVersionHandler(c)
 }
 
+// DeleteFileVersionMetadata handles DELETE requests on
+// /sharings/drives/:id/:file-id/:version-id.
+//
+// It can be used to delete an old version of a file.
+func DeleteFileVersionMetadata(c echo.Context, inst *instance.Instance, s *sharing.Sharing) error {
+	return files.DeleteFileVersionMetadata(c)
+}
+
 // GetDirSize returns the size of a directory (the sum of the size of the files
 // in this directory, including those in subdirectories).
 func GetDirSize(c echo.Context, inst *instance.Instance, s *sharing.Sharing) error {
@@ -1324,6 +1332,7 @@ func drivesRoutes(router *echo.Group) {
 	drive.HEAD("/download/:file-id/:version-id", proxy(ReadFileContentFromVersion, true))
 	drive.GET("/download/:file-id/:version-id", proxy(ReadFileContentFromVersion, true))
 	drive.POST("/:file-id/versions", proxy(CopyVersionHandler, true))
+	drive.DELETE("/:file-id/:version-id", proxy(DeleteFileVersionMetadata, true))
 
 	drive.GET("/_changes", proxy(ChangesFeed, true))
 

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -3903,6 +3903,52 @@ func TestFileRootSharedDriveReadRoutes(t *testing.T) {
 	})
 }
 
+func TestSharedDriveFileVersionDeletion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, eB, eD := env.createClients(t)
+
+	eB.PUT("/sharings/drives/"+env.firstSharingID+"/"+env.checklistID).
+		WithHeader("Authorization", "Bearer "+env.bettyToken).
+		WithHeader("Content-Type", "text/plain").
+		WithBytes([]byte("bar")).
+		Expect().Status(200)
+
+	versionID := eA.GET("/files/"+env.checklistID).
+		WithHeader("Authorization", "Bearer "+env.acmeToken).
+		Expect().Status(200).
+		JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+		Object().Path("$.data.relationships.old_versions.data[0].id").
+		String().NotEmpty().Raw()
+
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, env.firstSharingID)
+
+	eD.DELETE("/sharings/drives/"+env.firstSharingID+"/"+versionID).
+		WithHeader("Authorization", "Bearer "+env.daveToken).
+		Expect().Status(403)
+
+	eB.GET("/sharings/drives/"+env.firstSharingID+"/download/"+versionID).
+		WithHeader("Authorization", "Bearer "+env.bettyToken).
+		Expect().Status(200).
+		Body().IsEqual("foo")
+
+	eB.DELETE("/sharings/drives/"+env.firstSharingID+"/"+versionID).
+		WithHeader("Authorization", "Bearer "+env.bettyToken).
+		Expect().Status(204)
+
+	eB.GET("/sharings/drives/"+env.firstSharingID+"/download/"+versionID).
+		WithHeader("Authorization", "Bearer "+env.bettyToken).
+		Expect().Status(404)
+
+	eB.GET("/sharings/drives/"+env.firstSharingID+"/download/"+env.checklistID).
+		WithHeader("Authorization", "Bearer "+env.bettyToken).
+		Expect().Status(200).
+		Body().IsEqual("bar")
+}
+
 func TestFileRootSharedDriveMutationRoutes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")


### PR DESCRIPTION
## Summary

- Add a shared drive route for permanently deleting a file version.
- Reuse the existing version deletion handler with shared drive permission checks.
- Cover read-only and writable recipients and document the endpoint.