### PR TITLE
feat(rag): add the io.cozy.ai.chat.rag doctype

### DIFF
--- a/model/rag/index_status_doc.go
+++ b/model/rag/index_status_doc.go
@@ -1,0 +1,65 @@
+package rag
+
+import (
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/jsonapi"
+)
+
+// IndexStatus is the RAG indexation status of a file. Its identifier is the
+// identifier of the file it describes.
+type IndexStatus struct {
+	DocID  string `json:"_id,omitempty"`
+	DocRev string `json:"_rev,omitempty"`
+
+	Indexed         bool       `json:"indexed"`
+	Status          string     `json:"status,omitempty"`
+	LastSuccessDate *time.Time `json:"lastSuccessDate,omitempty"`
+	LastErrorDate   *time.Time `json:"lastErrorDate,omitempty"`
+
+	// Read it with relData["_id"], not with Relationship.ResourceIdentifier():
+	// the latter looks for "id"/"type" and would silently return an empty
+	// reference.
+	Rels jsonapi.RelationshipMap `json:"relationships,omitempty"`
+}
+
+func (s *IndexStatus) ID() string        { return s.DocID }
+func (s *IndexStatus) Rev() string       { return s.DocRev }
+func (s *IndexStatus) DocType() string   { return consts.ChatRAG }
+func (s *IndexStatus) SetID(id string)   { s.DocID = id }
+func (s *IndexStatus) SetRev(rev string) { s.DocRev = rev }
+
+func (s *IndexStatus) Clone() couchdb.Doc {
+	cloned := *s
+	if s.LastSuccessDate != nil {
+		at := *s.LastSuccessDate
+		cloned.LastSuccessDate = &at
+	}
+	if s.LastErrorDate != nil {
+		at := *s.LastErrorDate
+		cloned.LastErrorDate = &at
+	}
+	if s.Rels != nil {
+		cloned.Rels = make(jsonapi.RelationshipMap, len(s.Rels))
+		for k, v := range s.Rels {
+			cloned.Rels[k] = v
+		}
+	}
+	return &cloned
+}
+
+func NewIndexStatus(fileID string) *IndexStatus {
+	return &IndexStatus{
+		DocID: fileID,
+		Rels: jsonapi.RelationshipMap{
+			"file": jsonapi.Relationship{
+				Data: struct {
+					ID   string `json:"_id"`
+					Type string `json:"_type"`
+				}{ID: fileID, Type: consts.Files},
+			},
+		},
+	}
+}

--- a/model/rag/index_status_doc_test.go
+++ b/model/rag/index_status_doc_test.go
@@ -1,0 +1,54 @@
+package rag
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewIndexStatus(t *testing.T) {
+	doc := NewIndexStatus("a1b2c3")
+
+	assert.Equal(t, "a1b2c3", doc.ID())
+	assert.Equal(t, consts.ChatRAG, doc.DocType())
+
+	// Apps read the relationship in the "_id"/"_type" format, not the
+	// "id"/"type" one used by referenced_by.
+	raw, err := json.Marshal(doc)
+	require.NoError(t, err)
+
+	var out struct {
+		Rels struct {
+			File struct {
+				Data struct {
+					ID   string `json:"_id"`
+					Type string `json:"_type"`
+				} `json:"data"`
+			} `json:"file"`
+		} `json:"relationships"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, "a1b2c3", out.Rels.File.Data.ID)
+	assert.Equal(t, consts.Files, out.Rels.File.Data.Type)
+}
+
+func TestIndexStatusClone(t *testing.T) {
+	at := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	doc := NewIndexStatus("a1b2c3")
+	doc.Indexed = true
+	doc.LastSuccessDate = &at
+
+	cloned := doc.Clone().(*IndexStatus)
+	other := at.Add(time.Hour)
+	cloned.LastSuccessDate = &other
+	cloned.Indexed = false
+	delete(cloned.Rels, "file")
+
+	assert.True(t, doc.Indexed)
+	assert.Equal(t, at, *doc.LastSuccessDate)
+	assert.Contains(t, doc.Rels, "file")
+}

--- a/pkg/consts/doctype.go
+++ b/pkg/consts/doctype.go
@@ -151,4 +151,6 @@ const (
 	ChatConversations = "io.cozy.ai.chat.conversations"
 	// ChatEvents doc type is used for RAG events about a chat conversation.
 	ChatEvents = "io.cozy.ai.chat.events"
+	// ChatRAG doc type is used for the RAG indexation status of a file.
+	ChatRAG = "io.cozy.ai.chat.rag"
 )


### PR DESCRIPTION
This doctype holds the RAG indexation status of a file. Its identifier is the identifier of the file it describes, and it carries a relationship to that file in the "_id"/"_type" format read by the apps.