### PR TITLE
feat(rag): record the index status on a callback route

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -42,6 +42,53 @@ can be indexed by enabling the following feature flags:
 - `rag.index.video.enabled`
 - `rag.index.audio.enabled`
 
+### POST /ai/index/status
+
+The RAG indexer reports the indexation status of a file on this route. The
+status is saved on an `io.cozy.ai.chat.rag` document whose identifier is the
+identifier of the file.
+
+This route has no authentication yet.
+
+#### Request
+
+```http
+POST /ai/index/status HTTP/1.1
+Host: alice.example.net
+Content-Type: application/json
+```
+
+```json
+{
+  "partition": "alice.example.net",
+  "file_id": "e21dce8058b9013d800a18c04daba326",
+  "status": "success",
+  "timestamp": "2026-08-28T13:24:07.576Z",
+  "metadata": {
+    "version": "3-6a1b0b8a51a4e0e0a3b7f0f1d2c3b4a5"
+  }
+}
+```
+
+The `status` can be `success`, `error` or `notsupported`. The `version` is the
+revision of the file the status is about, as it was given to the indexer. It is
+mandatory: callbacks are ordered on it, and it is saved on the status document
+so that a client can tell whether the current revision of the file is the one
+described.
+
+#### Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
+A callback is answered with a `400 Bad Request` when its payload is invalid or
+when its partition is not this instance, and with a `500 Internal Server Error`
+when the status could not be saved.
+
+A callback about a revision that is not newer than the one already saved is
+accepted but not saved, and answered with a `204`.
+
 ## openRAG
 
 Some openRAG API are directly exposed through cozy-stack.

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -44,9 +44,9 @@ can be indexed by enabling the following feature flags:
 
 ### POST /ai/index/status
 
-The RAG indexer reports the indexation status of a file on this route. The
+The RAG indexer reports the indexation status of a document on this route. The
 status is saved on an `io.cozy.ai.chat.rag` document whose identifier is the
-identifier of the file.
+identifier of the document it describes. Only files are indexed for now.
 
 This route has no authentication yet.
 
@@ -65,16 +65,21 @@ Content-Type: application/json
   "status": "success",
   "timestamp": "2026-08-28T13:24:07.576Z",
   "metadata": {
-    "version": "3-6a1b0b8a51a4e0e0a3b7f0f1d2c3b4a5"
+    "doc_rev": "3-6a1b0b8a51a4e0e0a3b7f0f1d2c3b4a5",
+    "datetime": "2026-08-20T08:12:00.000Z",
+    "doctype": "io.cozy.files"
   }
 }
 ```
 
-The `status` can be `success`, `error` or `notsupported`. The `version` is the
-revision of the file the status is about, as it was given to the indexer. It is
-mandatory: callbacks are ordered on it, and it is saved on the status document
-so that a client can tell whether the current revision of the file is the one
+The `status` can be `success`, `error` or `notsupported`. The `doc_rev` is the
+revision of the document the status is about, as it was given to the indexer. It
+is mandatory: callbacks are ordered on it, and a callback that carries none
+cannot be placed. It is saved on the status document as `docRev`, so that a
+client can tell whether the current revision of the document is the one
 described.
+
+The indexer echoes back more than `doc_rev`, but the other fields are ignored.
 
 #### Response
 
@@ -86,8 +91,9 @@ A callback is answered with a `400 Bad Request` when its payload is invalid or
 when its partition is not this instance, and with a `500 Internal Server Error`
 when the status could not be saved.
 
-A callback about a revision that is not newer than the one already saved is
-accepted but not saved, and answered with a `204`.
+A callback about a revision older than the one already saved is accepted but not
+saved, and answered with a `204`. One about the same revision describes the same
+indexation and is saved.
 
 ## openRAG
 

--- a/model/rag/index_status_doc.go
+++ b/model/rag/index_status_doc.go
@@ -8,15 +8,17 @@ import (
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
 )
 
-// IndexStatus is the RAG indexation status of a file. Its identifier is the
-// identifier of the file it describes.
+// IndexStatus is the RAG indexation status of a document. Its identifier is
+// the identifier of the document it describes.
 type IndexStatus struct {
-	DocID  string `json:"_id,omitempty"`
-	DocRev string `json:"_rev,omitempty"`
+	CouchID  string `json:"_id,omitempty"`
+	CouchRev string `json:"_rev,omitempty"`
 
-	Indexed         bool       `json:"indexed"`
-	Status          string     `json:"status,omitempty"`
-	FileRev         string     `json:"fileRev,omitempty"`
+	Indexed bool   `json:"indexed"`
+	Status  string `json:"status,omitempty"`
+	// Revision of the io.cozy.files document this status describes. Callbacks
+	// are ordered on it.
+	DocRev          string     `json:"docRev,omitempty"`
 	LastSuccessDate *time.Time `json:"lastSuccessDate,omitempty"`
 	LastErrorDate   *time.Time `json:"lastErrorDate,omitempty"`
 
@@ -26,11 +28,11 @@ type IndexStatus struct {
 	Rels jsonapi.RelationshipMap `json:"relationships,omitempty"`
 }
 
-func (s *IndexStatus) ID() string        { return s.DocID }
-func (s *IndexStatus) Rev() string       { return s.DocRev }
+func (s *IndexStatus) ID() string        { return s.CouchID }
+func (s *IndexStatus) Rev() string       { return s.CouchRev }
 func (s *IndexStatus) DocType() string   { return consts.ChatRAG }
-func (s *IndexStatus) SetID(id string)   { s.DocID = id }
-func (s *IndexStatus) SetRev(rev string) { s.DocRev = rev }
+func (s *IndexStatus) SetID(id string)   { s.CouchID = id }
+func (s *IndexStatus) SetRev(rev string) { s.CouchRev = rev }
 
 func (s *IndexStatus) Clone() couchdb.Doc {
 	cloned := *s
@@ -51,15 +53,15 @@ func (s *IndexStatus) Clone() couchdb.Doc {
 	return &cloned
 }
 
-func NewIndexStatus(fileID string) *IndexStatus {
+func NewIndexStatus(docID string) *IndexStatus {
 	return &IndexStatus{
-		DocID: fileID,
+		CouchID: docID,
 		Rels: jsonapi.RelationshipMap{
-			"file": jsonapi.Relationship{
+			"doc": jsonapi.Relationship{
 				Data: struct {
 					ID   string `json:"_id"`
 					Type string `json:"_type"`
-				}{ID: fileID, Type: consts.Files},
+				}{ID: docID, Type: consts.Files},
 			},
 		},
 	}

--- a/model/rag/index_status_doc.go
+++ b/model/rag/index_status_doc.go
@@ -16,6 +16,7 @@ type IndexStatus struct {
 
 	Indexed         bool       `json:"indexed"`
 	Status          string     `json:"status,omitempty"`
+	FileRev         string     `json:"fileRev,omitempty"`
 	LastSuccessDate *time.Time `json:"lastSuccessDate,omitempty"`
 	LastErrorDate   *time.Time `json:"lastErrorDate,omitempty"`
 

--- a/model/rag/index_status_doc_test.go
+++ b/model/rag/index_status_doc_test.go
@@ -23,17 +23,17 @@ func TestNewIndexStatus(t *testing.T) {
 
 	var out struct {
 		Rels struct {
-			File struct {
+			Doc struct {
 				Data struct {
 					ID   string `json:"_id"`
 					Type string `json:"_type"`
 				} `json:"data"`
-			} `json:"file"`
+			} `json:"doc"`
 		} `json:"relationships"`
 	}
 	require.NoError(t, json.Unmarshal(raw, &out))
-	assert.Equal(t, "a1b2c3", out.Rels.File.Data.ID)
-	assert.Equal(t, consts.Files, out.Rels.File.Data.Type)
+	assert.Equal(t, "a1b2c3", out.Rels.Doc.Data.ID)
+	assert.Equal(t, consts.Files, out.Rels.Doc.Data.Type)
 }
 
 func TestIndexStatusClone(t *testing.T) {
@@ -46,9 +46,9 @@ func TestIndexStatusClone(t *testing.T) {
 	other := at.Add(time.Hour)
 	cloned.LastSuccessDate = &other
 	cloned.Indexed = false
-	delete(cloned.Rels, "file")
+	delete(cloned.Rels, "doc")
 
 	assert.True(t, doc.Indexed)
 	assert.Equal(t, at, *doc.LastSuccessDate)
-	assert.Contains(t, doc.Rels, "file")
+	assert.Contains(t, doc.Rels, "doc")
 }

--- a/model/rag/status.go
+++ b/model/rag/status.go
@@ -1,0 +1,81 @@
+package rag
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/revision"
+)
+
+const (
+	StatusSuccess      = "success"
+	StatusError        = "error"
+	StatusNotSupported = "notsupported"
+)
+
+// IndexStatusPath is the path of the route on which the RAG indexer posts the
+// indexation status of a file. It is what inst.PageURL takes to build the
+// callback_url given to the indexer.
+const IndexStatusPath = "/ai/index/status"
+
+func SetIndexStatus(inst *instance.Instance, fileID, newStatus, rev string, timestamp time.Time) error {
+	if timestamp.IsZero() {
+		timestamp = time.Now()
+	}
+	log := inst.Logger().WithNamespace("rag")
+
+	// A missing file is a no-op: it may have been deleted before its callback.
+	if _, err := inst.VFS().FileByID(fileID); err != nil {
+		if couchdb.IsNotFoundError(err) || errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	doc := NewIndexStatus(fileID)
+	err := couchdb.GetDoc(inst, consts.ChatRAG, fileID, doc)
+	switch {
+	case err == nil:
+		// Dropped whole: such a callback must not claim the file is indexed, as
+		// a more recent status (e.g. a delete) may say otherwise.
+		if isOutdated(rev, doc.FileRev) {
+			log.Debugf("SetIndexStatus: dropping status=%s on %s (outdated file revision)", newStatus, fileID)
+			return nil
+		}
+	case couchdb.IsNotFoundError(err) || couchdb.IsNoDatabaseError(err):
+		doc = NewIndexStatus(fileID)
+	default:
+		return err
+	}
+
+	// Kept so that a client can tell whether the current revision of the file
+	// is the one this status describes.
+	doc.FileRev = rev
+	applyStatus(doc, newStatus, timestamp)
+	return couchdb.Upsert(inst, doc)
+}
+
+// isOutdated reports whether a callback about the rev revision of a file is not
+// newer than the stored one.
+func isOutdated(rev, storedRev string) bool {
+	if rev == "" || storedRev == "" {
+		return false
+	}
+	return revision.Generation(rev) <= revision.Generation(storedRev)
+}
+
+func applyStatus(doc *IndexStatus, newStatus string, timestamp time.Time) {
+	doc.Status = newStatus
+	switch newStatus {
+	case StatusSuccess:
+		doc.Indexed = true
+		doc.LastSuccessDate = &timestamp
+	case StatusError:
+		// Indexed is preserved: stays true if the file was previously indexed.
+		doc.LastErrorDate = &timestamp
+	}
+}

--- a/model/rag/status.go
+++ b/model/rag/status.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/revision"
@@ -22,50 +23,61 @@ const (
 // callback_url given to the indexer.
 const IndexStatusPath = "/ai/index/status"
 
-func SetIndexStatus(inst *instance.Instance, fileID, newStatus, rev string, timestamp time.Time) error {
+func SetIndexStatus(inst *instance.Instance, docID, newStatus, rev string, timestamp time.Time) error {
 	if timestamp.IsZero() {
 		timestamp = time.Now()
 	}
 	log := inst.Logger().WithNamespace("rag")
 
+	// couchdb.Upsert overwrites the revision it finds instead of raising a
+	// conflict, so every read this decision rests on must be under the lock.
+	mu := config.Lock().ReadWrite(inst, "rag/index-status/"+docID)
+	if err := mu.Lock(); err != nil {
+		return err
+	}
+	defer mu.Unlock()
+
 	// A missing file is a no-op: it may have been deleted before its callback.
-	if _, err := inst.VFS().FileByID(fileID); err != nil {
+	file, err := inst.VFS().FileByID(docID)
+	if err != nil {
 		if couchdb.IsNotFoundError(err) || errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return err
 	}
+	// A trashed file is out of the index: a callback still in flight must not
+	// claim it is indexed.
+	if file.Trashed {
+		return nil
+	}
 
-	doc := NewIndexStatus(fileID)
-	err := couchdb.GetDoc(inst, consts.ChatRAG, fileID, doc)
+	doc := NewIndexStatus(docID)
+	err = couchdb.GetDoc(inst, consts.ChatRAG, docID, doc)
 	switch {
 	case err == nil:
-		// Dropped whole: such a callback must not claim the file is indexed, as
-		// a more recent status (e.g. a delete) may say otherwise.
-		if isOutdated(rev, doc.FileRev) {
-			log.Debugf("SetIndexStatus: dropping status=%s on %s (outdated file revision)", newStatus, fileID)
+		if isOutdated(rev, doc.DocRev) {
+			log.Debugf("SetIndexStatus: dropping status=%s on %s (outdated revision)", newStatus, docID)
 			return nil
 		}
 	case couchdb.IsNotFoundError(err) || couchdb.IsNoDatabaseError(err):
-		doc = NewIndexStatus(fileID)
+		doc = NewIndexStatus(docID)
 	default:
 		return err
 	}
 
-	// Kept so that a client can tell whether the current revision of the file
-	// is the one this status describes.
-	doc.FileRev = rev
+	doc.DocRev = rev
 	applyStatus(doc, newStatus, timestamp)
 	return couchdb.Upsert(inst, doc)
 }
 
-// isOutdated reports whether a callback about the rev revision of a file is not
-// newer than the stored one.
+// isOutdated reports whether a callback is older than the stored status. Two
+// callbacks about the same revision describe the same indexation, so the last
+// one is kept.
 func isOutdated(rev, storedRev string) bool {
 	if rev == "" || storedRev == "" {
 		return false
 	}
-	return revision.Generation(rev) <= revision.Generation(storedRev)
+	return revision.Generation(rev) < revision.Generation(storedRev)
 }
 
 func applyStatus(doc *IndexStatus, newStatus string, timestamp time.Time) {

--- a/model/rag/status_test.go
+++ b/model/rag/status_test.go
@@ -1,0 +1,57 @@
+package rag
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyStatus(t *testing.T) {
+	t1 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	t.Run("success sets Indexed=true and LastSuccessDate", func(t *testing.T) {
+		doc := NewIndexStatus("a1b2c3")
+		applyStatus(doc, StatusSuccess, t1)
+		assert.True(t, doc.Indexed)
+		assert.Equal(t, StatusSuccess, doc.Status)
+		assert.Equal(t, t1, *doc.LastSuccessDate)
+		assert.Nil(t, doc.LastErrorDate)
+	})
+
+	t.Run("error without prior success keeps Indexed=false", func(t *testing.T) {
+		doc := NewIndexStatus("a1b2c3")
+		applyStatus(doc, StatusError, t1)
+		assert.False(t, doc.Indexed)
+		assert.Equal(t, StatusError, doc.Status)
+		assert.Equal(t, t1, *doc.LastErrorDate)
+		assert.Nil(t, doc.LastSuccessDate)
+	})
+
+	t.Run("error after success preserves Indexed=true", func(t *testing.T) {
+		doc := NewIndexStatus("a1b2c3")
+		doc.Indexed = true
+		applyStatus(doc, StatusError, t1)
+		assert.True(t, doc.Indexed)
+		assert.Equal(t, StatusError, doc.Status)
+		assert.Equal(t, t1, *doc.LastErrorDate)
+	})
+
+	t.Run("notsupported only sets Status", func(t *testing.T) {
+		doc := NewIndexStatus("a1b2c3")
+		doc.Indexed = true
+		applyStatus(doc, StatusNotSupported, t1)
+		assert.True(t, doc.Indexed)
+		assert.Equal(t, StatusNotSupported, doc.Status)
+		assert.Nil(t, doc.LastSuccessDate)
+		assert.Nil(t, doc.LastErrorDate)
+	})
+}
+
+func TestIsOutdated(t *testing.T) {
+	assert.True(t, isOutdated("2-abc", "3-def"))  // an older revision
+	assert.True(t, isOutdated("3-abc", "3-def"))  // the revision already stored
+	assert.False(t, isOutdated("4-abc", "3-def")) // a newer revision
+	assert.False(t, isOutdated("", "3-def"))      // no revision in the callback
+	assert.False(t, isOutdated("3-abc", ""))      // nothing stored yet
+}

--- a/model/rag/status_test.go
+++ b/model/rag/status_test.go
@@ -50,7 +50,7 @@ func TestApplyStatus(t *testing.T) {
 
 func TestIsOutdated(t *testing.T) {
 	assert.True(t, isOutdated("2-abc", "3-def"))  // an older revision
-	assert.True(t, isOutdated("3-abc", "3-def"))  // the revision already stored
+	assert.False(t, isOutdated("3-abc", "3-def")) // the revision already stored
 	assert.False(t, isOutdated("4-abc", "3-def")) // a newer revision
 	assert.False(t, isOutdated("", "3-def"))      // no revision in the callback
 	assert.False(t, isOutdated("3-abc", ""))      // nothing stored yet

--- a/web/ai/ai.go
+++ b/web/ai/ai.go
@@ -78,4 +78,5 @@ func Routes(router *echo.Group) {
 	router.POST("/chat/conversations/:id", Chat)
 	router.POST("/v1/chat/completions", OpenAICompletion)
 	router.POST("/v1/tools/execute", ExecuteTool)
+	router.POST("/index/status", IndexStatus)
 }

--- a/web/ai/index_status.go
+++ b/web/ai/index_status.go
@@ -15,13 +15,13 @@ import (
 // statusMessage is the payload posted by the RAG indexer on the callback URL.
 type statusMessage struct {
 	Partition string `json:"partition"`
-	FileID    string `json:"file_id"`
+	DocID     string `json:"file_id"`
 	Status    string `json:"status"`    // "success" | "error" | "notsupported"
 	Timestamp string `json:"timestamp"` // RFC3339Nano
-	// The "version" field holds the revision of the file the status is about.
-	// Callbacks are ordered on it.
+	// The indexer echoes back the metadata it was given; only the revision of
+	// the document the status is about is read. Callbacks are ordered on it.
 	Metadata struct {
-		Version string `json:"version"`
+		DocRev string `json:"doc_rev"`
 	} `json:"metadata"`
 }
 
@@ -45,13 +45,13 @@ func IndexStatus(c echo.Context) error {
 	if err := c.Bind(&msg); err != nil {
 		return badRequest(err)
 	}
-	if msg.FileID == "" {
+	if msg.DocID == "" {
 		return badRequest(errors.New("missing file_id in payload"))
 	}
 	// Callbacks are ordered on the file revision they carry, so one without it
 	// cannot be placed and is refused.
-	if msg.Metadata.Version == "" {
-		return badRequest(fmt.Errorf("missing metadata.version for file %s", msg.FileID))
+	if msg.Metadata.DocRev == "" {
+		return badRequest(fmt.Errorf("missing metadata.doc_rev for doc %s", msg.DocID))
 	}
 
 	// The partition is the domain the file was sent for indexation from. A
@@ -64,7 +64,7 @@ func IndexStatus(c echo.Context) error {
 	switch msg.Status {
 	case rag.StatusSuccess, rag.StatusError, rag.StatusNotSupported:
 	default:
-		return badRequest(fmt.Errorf("unknown status %q for file %s", msg.Status, msg.FileID))
+		return badRequest(fmt.Errorf("unknown status %q for doc %s", msg.Status, msg.DocID))
 	}
 
 	var ts time.Time
@@ -72,19 +72,19 @@ func IndexStatus(c echo.Context) error {
 		var err error
 		ts, err = time.Parse(time.RFC3339Nano, msg.Timestamp)
 		if err != nil {
-			log.Warnf("index status: invalid timestamp %q for file %s, using now", msg.Timestamp, msg.FileID)
+			log.Warnf("index status: invalid timestamp %q for doc %s, using now", msg.Timestamp, msg.DocID)
 			ts = time.Now()
 		}
 	} else {
-		log.Warnf("index status: missing timestamp for file %s, using now", msg.FileID)
+		log.Warnf("index status: missing timestamp for doc %s, using now", msg.DocID)
 		ts = time.Now()
 	}
 
-	log.Debugf("index status: file %s status=%s ts=%s", msg.FileID, msg.Status, ts)
+	log.Debugf("index status: doc %s status=%s ts=%s", msg.DocID, msg.Status, ts)
 
-	if err := rag.SetIndexStatus(inst, msg.FileID, msg.Status, msg.Metadata.Version, ts); err != nil {
+	if err := rag.SetIndexStatus(inst, msg.DocID, msg.Status, msg.Metadata.DocRev, ts); err != nil {
 		// The indexer does not replay a failed callback: this status is lost.
-		log.Errorf("index status: cannot save status=%s for file %s: %s", msg.Status, msg.FileID, err)
+		log.Errorf("index status: cannot save status=%s for doc %s: %s", msg.Status, msg.DocID, err)
 		return jsonapi.InternalServerError(err)
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/web/ai/index_status.go
+++ b/web/ai/index_status.go
@@ -1,0 +1,91 @@
+package ai
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/cozy/cozy-stack/model/rag"
+	"github.com/cozy/cozy-stack/pkg/jsonapi"
+	"github.com/cozy/cozy-stack/web/middlewares"
+	"github.com/labstack/echo/v4"
+)
+
+// statusMessage is the payload posted by the RAG indexer on the callback URL.
+type statusMessage struct {
+	Partition string `json:"partition"`
+	FileID    string `json:"file_id"`
+	Status    string `json:"status"`    // "success" | "error" | "notsupported"
+	Timestamp string `json:"timestamp"` // RFC3339Nano
+	// The "version" field holds the revision of the file the status is about.
+	// Callbacks are ordered on it.
+	Metadata struct {
+		Version string `json:"version"`
+	} `json:"metadata"`
+}
+
+// IndexStatus is the callback route used by the RAG indexer to report the
+// indexation status of a file. This route has no authentication.
+//
+// A malformed payload is answered with a 400: the indexer must not replay it.
+// A failure on our side is answered with a 500, so that it can be replayed.
+func IndexStatus(c echo.Context) error {
+	inst := middlewares.GetInstance(c)
+	log := inst.Logger().WithNamespace("rag")
+
+	// A rejected callback is never replayed by the indexer, so it is logged
+	// here: the error handler only logs on dev releases.
+	badRequest := func(err error) error {
+		log.Warnf("index status: rejecting callback: %s", err)
+		return jsonapi.BadRequest(err)
+	}
+
+	var msg statusMessage
+	if err := c.Bind(&msg); err != nil {
+		return badRequest(err)
+	}
+	if msg.FileID == "" {
+		return badRequest(errors.New("missing file_id in payload"))
+	}
+	// Callbacks are ordered on the file revision they carry, so one without it
+	// cannot be placed and is refused.
+	if msg.Metadata.Version == "" {
+		return badRequest(fmt.Errorf("missing metadata.version for file %s", msg.FileID))
+	}
+
+	// The partition is the domain the file was sent for indexation from. A
+	// mismatch means the callback was delivered to the wrong instance, where
+	// the same file ID designates another file entirely.
+	if msg.Partition != "" && msg.Partition != inst.Domain {
+		return badRequest(fmt.Errorf("partition %q does not match this instance", msg.Partition))
+	}
+
+	switch msg.Status {
+	case rag.StatusSuccess, rag.StatusError, rag.StatusNotSupported:
+	default:
+		return badRequest(fmt.Errorf("unknown status %q for file %s", msg.Status, msg.FileID))
+	}
+
+	var ts time.Time
+	if msg.Timestamp != "" {
+		var err error
+		ts, err = time.Parse(time.RFC3339Nano, msg.Timestamp)
+		if err != nil {
+			log.Warnf("index status: invalid timestamp %q for file %s, using now", msg.Timestamp, msg.FileID)
+			ts = time.Now()
+		}
+	} else {
+		log.Warnf("index status: missing timestamp for file %s, using now", msg.FileID)
+		ts = time.Now()
+	}
+
+	log.Debugf("index status: file %s status=%s ts=%s", msg.FileID, msg.Status, ts)
+
+	if err := rag.SetIndexStatus(inst, msg.FileID, msg.Status, msg.Metadata.Version, ts); err != nil {
+		// The indexer does not replay a failed callback: this status is lost.
+		log.Errorf("index status: cannot save status=%s for file %s: %s", msg.Status, msg.FileID, err)
+		return jsonapi.InternalServerError(err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}

--- a/web/ai/index_status_test.go
+++ b/web/ai/index_status_test.go
@@ -55,7 +55,7 @@ func TestIndexStatus(t *testing.T) {
 			"file_id":   doc.DocID,
 			"status":    "success",
 			"timestamp": at.Format(time.RFC3339Nano),
-			"metadata":  map[string]interface{}{"version": doc.Rev()},
+			"metadata":  map[string]interface{}{"doc_rev": doc.Rev()},
 		}).Status(204)
 
 		status := getStatus(t, inst, doc.DocID)
@@ -75,12 +75,12 @@ func TestIndexStatus(t *testing.T) {
 			"file_id":   doc.DocID,
 			"status":    "success",
 			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
-			"metadata":  map[string]interface{}{"version": doc.Rev()},
+			"metadata":  map[string]interface{}{"doc_rev": doc.Rev()},
 		}).Status(204)
 
 		status := getStatus(t, inst, doc.DocID)
 		require.Equal(t, doc.DocID, status.ID())
-		rel, ok := status.Rels["file"]
+		rel, ok := status.Rels["doc"]
 		require.True(t, ok)
 		data, ok := rel.Data.(map[string]interface{})
 		require.True(t, ok)
@@ -99,7 +99,7 @@ func TestIndexStatus(t *testing.T) {
 			"file_id":   doc.DocID,
 			"status":    "error",
 			"timestamp": at.Format(time.RFC3339Nano),
-			"metadata":  map[string]interface{}{"version": doc.Rev()},
+			"metadata":  map[string]interface{}{"doc_rev": doc.Rev()},
 		}).Status(204)
 
 		status := getStatus(t, inst, doc.DocID)
@@ -120,7 +120,7 @@ func TestIndexStatus(t *testing.T) {
 			"file_id":   doc.DocID,
 			"status":    "success",
 			"timestamp": now.Add(-time.Hour).Format(time.RFC3339Nano),
-			"metadata":  map[string]interface{}{"version": "3-" + strings.Repeat("a", 32)},
+			"metadata":  map[string]interface{}{"doc_rev": "3-" + strings.Repeat("a", 32)},
 		}).Status(204)
 
 		postStatus(t, map[string]interface{}{
@@ -128,7 +128,7 @@ func TestIndexStatus(t *testing.T) {
 			"file_id":   doc.DocID,
 			"status":    "notsupported",
 			"timestamp": now.Format(time.RFC3339Nano),
-			"metadata":  map[string]interface{}{"version": "4-" + strings.Repeat("b", 32)},
+			"metadata":  map[string]interface{}{"doc_rev": "4-" + strings.Repeat("b", 32)},
 		}).Status(204)
 
 		status := getStatus(t, inst, doc.DocID)
@@ -149,7 +149,7 @@ func TestIndexStatus(t *testing.T) {
 			"file_id":   doc.DocID,
 			"status":    "success",
 			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
-			"metadata":  map[string]interface{}{"version": "5-" + strings.Repeat("a", 32)},
+			"metadata":  map[string]interface{}{"doc_rev": "5-" + strings.Repeat("a", 32)},
 		}).Status(204)
 
 		// A revision that is not newer than the stored one means the callback
@@ -160,7 +160,7 @@ func TestIndexStatus(t *testing.T) {
 			"file_id":   doc.DocID,
 			"status":    "error",
 			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
-			"metadata":  map[string]interface{}{"version": "3-" + strings.Repeat("b", 32)},
+			"metadata":  map[string]interface{}{"doc_rev": "3-" + strings.Repeat("b", 32)},
 		}).Status(204)
 
 		status := getStatus(t, inst, doc.DocID)
@@ -179,10 +179,10 @@ func TestIndexStatus(t *testing.T) {
 			"file_id":   doc.DocID,
 			"status":    "success",
 			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
-			"metadata":  map[string]interface{}{"version": doc.Rev()},
+			"metadata":  map[string]interface{}{"doc_rev": doc.Rev()},
 		}).Status(204)
 
-		require.Equal(t, doc.Rev(), getStatus(t, inst, doc.DocID).FileRev)
+		require.Equal(t, doc.Rev(), getStatus(t, inst, doc.DocID).DocRev)
 	})
 
 	t.Run("a callback without a revision returns a 400", func(t *testing.T) {
@@ -198,7 +198,7 @@ func TestIndexStatus(t *testing.T) {
 			"partition": inst.Domain,
 			"file_id":   "any-file-id",
 			"status":    "weird",
-			"metadata":  map[string]interface{}{"version": "1-abc"},
+			"metadata":  map[string]interface{}{"doc_rev": "1-abc"},
 		}).Status(400)
 	})
 
@@ -207,7 +207,7 @@ func TestIndexStatus(t *testing.T) {
 			"partition": "somewhere-else.cozy.example",
 			"file_id":   "any-file-id",
 			"status":    "success",
-			"metadata":  map[string]interface{}{"version": "1-abc"},
+			"metadata":  map[string]interface{}{"doc_rev": "1-abc"},
 		}).Status(400)
 	})
 
@@ -215,7 +215,7 @@ func TestIndexStatus(t *testing.T) {
 		postStatus(t, map[string]interface{}{
 			"partition": inst.Domain,
 			"status":    "success",
-			"metadata":  map[string]interface{}{"version": "1-abc"},
+			"metadata":  map[string]interface{}{"doc_rev": "1-abc"},
 		}).Status(400)
 	})
 
@@ -228,7 +228,7 @@ func TestIndexStatus(t *testing.T) {
 			"partition": inst.Domain,
 			"file_id":   doc.DocID,
 			"status":    "success",
-			"metadata":  map[string]interface{}{"version": doc.Rev()},
+			"metadata":  map[string]interface{}{"doc_rev": doc.Rev()},
 		}).Status(204)
 
 		require.NotNil(t, getStatus(t, inst, doc.DocID).LastSuccessDate)
@@ -244,7 +244,7 @@ func TestIndexStatus(t *testing.T) {
 			"file_id":   doc.DocID,
 			"status":    "success",
 			"timestamp": "not-a-date",
-			"metadata":  map[string]interface{}{"version": doc.Rev()},
+			"metadata":  map[string]interface{}{"doc_rev": doc.Rev()},
 		}).Status(204)
 
 		require.NotNil(t, getStatus(t, inst, doc.DocID).LastSuccessDate)
@@ -255,15 +255,15 @@ func TestIndexStatus(t *testing.T) {
 			"partition": inst.Domain,
 			"file_id":   "non-existent-file-id",
 			"status":    "success",
-			"metadata":  map[string]interface{}{"version": "1-abc"},
+			"metadata":  map[string]interface{}{"doc_rev": "1-abc"},
 		}).Status(204)
 	})
 }
 
-func getStatus(t *testing.T, inst *instance.Instance, fileID string) *rag.IndexStatus {
+func getStatus(t *testing.T, inst *instance.Instance, docID string) *rag.IndexStatus {
 	t.Helper()
 	var status rag.IndexStatus
-	require.NoError(t, couchdb.GetDoc(inst, consts.ChatRAG, fileID, &status))
+	require.NoError(t, couchdb.GetDoc(inst, consts.ChatRAG, docID, &status))
 	return &status
 }
 

--- a/web/ai/index_status_test.go
+++ b/web/ai/index_status_test.go
@@ -1,0 +1,289 @@
+package ai
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/model/rag"
+	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/tests/testutils"
+	"github.com/cozy/cozy-stack/web/errors"
+	"github.com/gavv/httpexpect/v2"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance(&lifecycle.Options{})
+
+	ts := setup.GetTestServer("/ai", Routes)
+	ts.Config.Handler.(*echo.Echo).HTTPErrorHandler = errors.ErrorHandler
+	t.Cleanup(ts.Close)
+
+	postStatus := func(t *testing.T, payload map[string]interface{}) *httpexpect.Response {
+		t.Helper()
+		e := testutils.CreateTestClient(t, ts.URL)
+		// Built from the constant, so a drift between the route and the path
+		// given to the indexer as callback_url fails this test.
+		return e.POST(rag.IndexStatusPath).
+			WithHeader("Content-Type", "application/json").
+			WithJSON(payload).
+			Expect()
+	}
+
+	t.Run("success status sets Status=success and Indexed=true", func(t *testing.T) {
+		fs := inst.VFS()
+		doc := createStatusTestFile(t, fs, "rag-success.txt")
+		defer destroyStatusTestFile(t, fs, doc)
+
+		at := time.Now().UTC().Truncate(time.Second)
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"file_id":   doc.DocID,
+			"status":    "success",
+			"timestamp": at.Format(time.RFC3339Nano),
+			"metadata":  map[string]interface{}{"version": doc.Rev()},
+		}).Status(204)
+
+		status := getStatus(t, inst, doc.DocID)
+		require.True(t, status.Indexed)
+		require.Equal(t, rag.StatusSuccess, status.Status)
+		require.NotNil(t, status.LastSuccessDate)
+		require.Nil(t, status.LastErrorDate)
+	})
+
+	t.Run("the status document relates to the file", func(t *testing.T) {
+		fs := inst.VFS()
+		doc := createStatusTestFile(t, fs, "rag-rel.txt")
+		defer destroyStatusTestFile(t, fs, doc)
+
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"file_id":   doc.DocID,
+			"status":    "success",
+			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+			"metadata":  map[string]interface{}{"version": doc.Rev()},
+		}).Status(204)
+
+		status := getStatus(t, inst, doc.DocID)
+		require.Equal(t, doc.DocID, status.ID())
+		rel, ok := status.Rels["file"]
+		require.True(t, ok)
+		data, ok := rel.Data.(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, doc.DocID, data["_id"])
+		require.Equal(t, consts.Files, data["_type"])
+	})
+
+	t.Run("error status sets Status=error and preserves Indexed", func(t *testing.T) {
+		fs := inst.VFS()
+		doc := createStatusTestFile(t, fs, "rag-error.txt")
+		defer destroyStatusTestFile(t, fs, doc)
+
+		at := time.Now().UTC().Truncate(time.Second)
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"file_id":   doc.DocID,
+			"status":    "error",
+			"timestamp": at.Format(time.RFC3339Nano),
+			"metadata":  map[string]interface{}{"version": doc.Rev()},
+		}).Status(204)
+
+		status := getStatus(t, inst, doc.DocID)
+		require.False(t, status.Indexed)
+		require.Equal(t, rag.StatusError, status.Status)
+		require.Nil(t, status.LastSuccessDate)
+		require.NotNil(t, status.LastErrorDate)
+	})
+
+	t.Run("notsupported status leaves Indexed and the dates alone", func(t *testing.T) {
+		fs := inst.VFS()
+		doc := createStatusTestFile(t, fs, "rag-notsupported.txt")
+		defer destroyStatusTestFile(t, fs, doc)
+
+		now := time.Now().UTC()
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"file_id":   doc.DocID,
+			"status":    "success",
+			"timestamp": now.Add(-time.Hour).Format(time.RFC3339Nano),
+			"metadata":  map[string]interface{}{"version": "3-" + strings.Repeat("a", 32)},
+		}).Status(204)
+
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"file_id":   doc.DocID,
+			"status":    "notsupported",
+			"timestamp": now.Format(time.RFC3339Nano),
+			"metadata":  map[string]interface{}{"version": "4-" + strings.Repeat("b", 32)},
+		}).Status(204)
+
+		status := getStatus(t, inst, doc.DocID)
+		require.Equal(t, rag.StatusNotSupported, status.Status)
+		require.True(t, status.Indexed)
+		require.Nil(t, status.LastErrorDate)
+	})
+
+	// isOutdated is unit tested in model/rag/status_test.go; this case checks
+	// that SetIndexStatus actually applies it before writing.
+	t.Run("a callback about an outdated file revision is dropped", func(t *testing.T) {
+		fs := inst.VFS()
+		doc := createStatusTestFile(t, fs, "rag-outdated.txt")
+		defer destroyStatusTestFile(t, fs, doc)
+
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"file_id":   doc.DocID,
+			"status":    "success",
+			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+			"metadata":  map[string]interface{}{"version": "5-" + strings.Repeat("a", 32)},
+		}).Status(204)
+
+		// A revision that is not newer than the stored one means the callback
+		// describes a version the status has moved past: the file must not be
+		// claimed as indexed.
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"file_id":   doc.DocID,
+			"status":    "error",
+			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+			"metadata":  map[string]interface{}{"version": "3-" + strings.Repeat("b", 32)},
+		}).Status(204)
+
+		status := getStatus(t, inst, doc.DocID)
+		require.Equal(t, rag.StatusSuccess, status.Status)
+		require.True(t, status.Indexed)
+		require.Nil(t, status.LastErrorDate)
+	})
+
+	t.Run("the file revision is stored on the status document", func(t *testing.T) {
+		fs := inst.VFS()
+		doc := createStatusTestFile(t, fs, "rag-filerev.txt")
+		defer destroyStatusTestFile(t, fs, doc)
+
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"file_id":   doc.DocID,
+			"status":    "success",
+			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+			"metadata":  map[string]interface{}{"version": doc.Rev()},
+		}).Status(204)
+
+		require.Equal(t, doc.Rev(), getStatus(t, inst, doc.DocID).FileRev)
+	})
+
+	t.Run("a callback without a revision returns a 400", func(t *testing.T) {
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"file_id":   "any-file-id",
+			"status":    "success",
+		}).Status(400)
+	})
+
+	t.Run("unknown status returns a 400", func(t *testing.T) {
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"file_id":   "any-file-id",
+			"status":    "weird",
+			"metadata":  map[string]interface{}{"version": "1-abc"},
+		}).Status(400)
+	})
+
+	t.Run("a partition from another instance returns a 400", func(t *testing.T) {
+		postStatus(t, map[string]interface{}{
+			"partition": "somewhere-else.cozy.example",
+			"file_id":   "any-file-id",
+			"status":    "success",
+			"metadata":  map[string]interface{}{"version": "1-abc"},
+		}).Status(400)
+	})
+
+	t.Run("missing file_id returns a 400", func(t *testing.T) {
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"status":    "success",
+			"metadata":  map[string]interface{}{"version": "1-abc"},
+		}).Status(400)
+	})
+
+	t.Run("missing timestamp falls back to now", func(t *testing.T) {
+		fs := inst.VFS()
+		doc := createStatusTestFile(t, fs, "rag-no-ts.txt")
+		defer destroyStatusTestFile(t, fs, doc)
+
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"file_id":   doc.DocID,
+			"status":    "success",
+			"metadata":  map[string]interface{}{"version": doc.Rev()},
+		}).Status(204)
+
+		require.NotNil(t, getStatus(t, inst, doc.DocID).LastSuccessDate)
+	})
+
+	t.Run("malformed timestamp falls back to now", func(t *testing.T) {
+		fs := inst.VFS()
+		doc := createStatusTestFile(t, fs, "rag-bad-ts.txt")
+		defer destroyStatusTestFile(t, fs, doc)
+
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"file_id":   doc.DocID,
+			"status":    "success",
+			"timestamp": "not-a-date",
+			"metadata":  map[string]interface{}{"version": doc.Rev()},
+		}).Status(204)
+
+		require.NotNil(t, getStatus(t, inst, doc.DocID).LastSuccessDate)
+	})
+
+	t.Run("non-existent file_id is a no-op", func(t *testing.T) {
+		postStatus(t, map[string]interface{}{
+			"partition": inst.Domain,
+			"file_id":   "non-existent-file-id",
+			"status":    "success",
+			"metadata":  map[string]interface{}{"version": "1-abc"},
+		}).Status(204)
+	})
+}
+
+func getStatus(t *testing.T, inst *instance.Instance, fileID string) *rag.IndexStatus {
+	t.Helper()
+	var status rag.IndexStatus
+	require.NoError(t, couchdb.GetDoc(inst, consts.ChatRAG, fileID, &status))
+	return &status
+}
+
+func createStatusTestFile(t *testing.T, fs vfs.VFS, name string) *vfs.FileDoc {
+	t.Helper()
+	parent, err := fs.DirByPath("/")
+	require.NoError(t, err)
+	doc, err := vfs.NewFileDoc(name, parent.DocID, 4, nil, "text/plain", "text", time.Now(), false, false, false, nil)
+	require.NoError(t, err)
+	f, err := fs.CreateFile(doc, nil)
+	require.NoError(t, err)
+	_, err = f.Write([]byte("test"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	updated, err := fs.FileByID(doc.DocID)
+	require.NoError(t, err)
+	return updated
+}
+
+func destroyStatusTestFile(t *testing.T, fs vfs.VFS, doc *vfs.FileDoc) {
+	t.Helper()
+	_ = fs.DestroyFile(doc)
+}


### PR DESCRIPTION
The RAG indexer reports the indexation status of a file by posting on /ai/index/status, and the status is saved on an io.cozy.ai.chat.rag document.

Callbacks are ordered on the revision of the file they carry, which is mandatory and kept on the status document: one about a revision that is not newer than the one already described is dropped, so that it cannot claim the file is indexed when a more recent status says otherwise.