### PR TITLE
refactor(rag): send the callback URL and the file revision to the ind…

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -63,7 +63,6 @@ Content-Type: application/json
   "partition": "alice.example.net",
   "file_id": "e21dce8058b9013d800a18c04daba326",
   "status": "success",
-  "timestamp": "2026-08-28T13:24:07.576Z",
   "metadata": {
     "doc_rev": "3-6a1b0b8a51a4e0e0a3b7f0f1d2c3b4a5",
     "datetime": "2026-08-20T08:12:00.000Z",

--- a/model/rag/index.go
+++ b/model/rag/index.go
@@ -13,7 +13,6 @@ import (
 	"net/url"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/cozy/cozy-stack/model/feature"
 	"github.com/cozy/cozy-stack/model/instance"
@@ -134,7 +133,7 @@ func isClassAllowed(flags *feature.Flags, class string) bool {
 // that decides a file will not be indexed.
 func markNotSupported(inst *instance.Instance, change couchdb.Change) error {
 	rev, _ := change.Doc.Get("_rev").(string)
-	return SetIndexStatus(inst, change.DocID, StatusNotSupported, rev, time.Now())
+	return SetIndexStatus(inst, change.DocID, StatusNotSupported, rev)
 }
 
 func deleteFromRAG(inst *instance.Instance, fileID string) error {

--- a/model/rag/index.go
+++ b/model/rag/index.go
@@ -84,12 +84,10 @@ func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Chan
 	}
 
 	if change.Doc.Get("type") == consts.DirType {
-		// A directory move or rename rewrites the path of the directory and
-		// of all its descendant directories, but never touches the file docs
-		// they contain: those files may have silently entered or left a
-		// knowledge-base folder. Every descendant directory shows up in this
-		// same changes feed, so reconciling the direct file children of each
-		// changed directory covers the whole moved subtree.
+		// Moving a directory rewrites the path of every descendant directory
+		// but never touches the file docs, which may have silently entered or
+		// left a knowledge-base folder. Each descendant shows up in this same
+		// feed, so reconciling the direct children covers the whole subtree.
 		dirPath, _ := change.Doc.Get("path").(string)
 		if dirPath != "" && !strings.HasPrefix(dirPath, vfs.TrashDirName) {
 			reconcileDirChildren(inst, logger, kb(), change.DocID, dirPath)
@@ -105,7 +103,8 @@ func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Chan
 
 	class, _ := change.Doc.Get("class").(string)
 	if !isClassAllowed(flags, class) {
-		return markNotSupported(inst, change)
+		rev, _ := change.Doc.Get("_rev").(string)
+		return SetIndexStatus(inst, change.DocID, StatusNotSupported, rev)
 	}
 
 	if change.Deleted || change.Doc.Get("trashed") == true {
@@ -127,13 +126,6 @@ func isClassAllowed(flags *feature.Flags, class string) bool {
 		return allowed
 	}
 	return true
-}
-
-// markNotSupported records a status no emitter ever reports: it is the stack
-// that decides a file will not be indexed.
-func markNotSupported(inst *instance.Instance, change couchdb.Change) error {
-	rev, _ := change.Doc.Get("_rev").(string)
-	return SetIndexStatus(inst, change.DocID, StatusNotSupported, rev)
 }
 
 func deleteFromRAG(inst *instance.Instance, fileID string) error {
@@ -175,8 +167,7 @@ func needsIndexation(inst *instance.Instance, fileID, md5sum string) (needed, is
 }
 
 // indexedMD5Sum returns the md5sum the RAG server holds for the file. known is
-// false when it does not know the file at all, which decides between a POST
-// and a PUT.
+// false when it does not know the file at all.
 func indexedMD5Sum(server config.RAGServer, domain, fileID string) (md5sum string, known bool, err error) {
 	path := fmt.Sprintf("/partition/%s/file/%s", domain, url.PathEscape(fileID))
 	res, err := callRAG(server, http.MethodGet, nil, path, echo.MIMEApplicationJSON)
@@ -269,12 +260,9 @@ func upsertToRAG(inst *instance.Instance, doctype string, change couchdb.Change,
 	}
 
 	if (!isNewFile || attachUnknown) && res.StatusCode < 300 {
-		// For an existing file, the content changed but it may also have
-		// been moved/renamed at the same time: keep the knowledge-base
-		// workspaces in sync after a successful re-upload. For a new file
-		// whose membership could not be resolved before the upload
-		// (attachUnknown), this is the only chance to attach it: retry
-		// now that the transient path-resolution error may have cleared.
+		// A re-upload may also have moved the file. And for a new file whose
+		// membership could not be resolved before the upload, this is the only
+		// chance to attach it, now that the transient error may have cleared.
 		reconcileMembership(inst, logger, kb(), change.DocID, dirID)
 	}
 	return nil
@@ -303,7 +291,7 @@ func resolveWorkspaces(inst *instance.Instance, logger logger.Logger, kbc *kbCon
 }
 
 // resolveContent returns what to send to the RAG server. A note is sent as the
-// markdown it renders to, under a name given the markdown extension.
+// markdown it renders to.
 func resolveContent(inst *instance.Instance, change couchdb.Change) (string, io.ReadCloser, error) {
 	name, _ := change.Doc.Get("name").(string)
 	mime, _ := change.Doc.Get("mime").(string)
@@ -345,7 +333,6 @@ func resolveContent(inst *instance.Instance, change couchdb.Change) (string, io.
 	return name, f, nil
 }
 
-// ragUpload is what the RAG server needs to index one file.
 type ragUpload struct {
 	Server      config.RAGServer
 	Domain      string
@@ -429,9 +416,6 @@ func decodeMD5Sum(v interface{}) string {
 	s, _ := v.(string)
 	if s == "" {
 		return ""
-	}
-	if raw, err := hex.DecodeString(s); err == nil && len(raw) == md5Length {
-		return strings.ToLower(s)
 	}
 	raw, err := base64.StdEncoding.DecodeString(s)
 	if err != nil || len(raw) != md5Length {

--- a/model/rag/index.go
+++ b/model/rag/index.go
@@ -2,6 +2,8 @@ package rag
 
 import (
 	"bytes"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +13,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/cozy/cozy-stack/model/feature"
 	"github.com/cozy/cozy-stack/model/instance"
@@ -80,30 +83,7 @@ func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Chan
 	if strings.HasPrefix(change.DocID, "_design/") {
 		return nil
 	}
-	flags, err := feature.GetFlags(inst)
-	class, _ := change.Doc.Get("class").(string)
 
-	if class == consts.ImageClass {
-		// Index images only if flag allows it
-		allowImage, ok := flags.M["rag.index.image.enabled"].(bool)
-		if !ok || !allowImage {
-			return nil
-		}
-	}
-	if class == consts.VideoClass {
-		// Index videos only if flag allows it
-		allowVideo, ok := flags.M["rag.index.video.enabled"].(bool)
-		if !ok || !allowVideo {
-			return nil
-		}
-	}
-	if class == consts.AudioClass {
-		// Index audio only if flag allows it
-		allowAudio, ok := flags.M["rag.index.audio.enabled"].(bool)
-		if !ok || !allowAudio {
-			return nil
-		}
-	}
 	if change.Doc.Get("type") == consts.DirType {
 		// A directory move or rename rewrites the path of the directory and
 		// of all its descendant directories, but never touches the file docs
@@ -118,215 +98,347 @@ func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Chan
 		return nil
 	}
 
-	ragServer := inst.RAGServer()
-	if ragServer.URL == "" {
+	// An error only means some sources were unreachable, the flags are usable.
+	flags, _ := feature.GetFlags(inst)
+	if inst.RAGServer().URL == "" {
 		return errors.New("no RAG server configured")
 	}
-	u, err := url.Parse(ragServer.URL)
+
+	class, _ := change.Doc.Get("class").(string)
+	if !isClassAllowed(flags, class) {
+		return markNotSupported(inst, change)
+	}
+
+	if change.Deleted || change.Doc.Get("trashed") == true {
+		return deleteFromRAG(inst, change.DocID)
+	}
+	return upsertToRAG(inst, doctype, change, kb, logger)
+}
+
+func isClassAllowed(flags *feature.Flags, class string) bool {
+	switch class {
+	case consts.ImageClass:
+		allowed, _ := flags.M["rag.index.image.enabled"].(bool)
+		return allowed
+	case consts.VideoClass:
+		allowed, _ := flags.M["rag.index.video.enabled"].(bool)
+		return allowed
+	case consts.AudioClass:
+		allowed, _ := flags.M["rag.index.audio.enabled"].(bool)
+		return allowed
+	}
+	return true
+}
+
+// markNotSupported records a status no emitter ever reports: it is the stack
+// that decides a file will not be indexed.
+func markNotSupported(inst *instance.Instance, change couchdb.Change) error {
+	rev, _ := change.Doc.Get("_rev").(string)
+	return SetIndexStatus(inst, change.DocID, StatusNotSupported, rev, time.Now())
+}
+
+func deleteFromRAG(inst *instance.Instance, fileID string) error {
+	if err := deleteFromRAGHTTP(inst.RAGServer(), inst.Domain, fileID); err != nil {
+		return err
+	}
+	return DeleteIndexStatus(inst, fileID)
+}
+
+func deleteFromRAGHTTP(server config.RAGServer, domain, fileID string) error {
+	path := fmt.Sprintf("/indexer/partition/%s/file/%s", domain, url.PathEscape(fileID))
+	res, err := callRAG(server, http.MethodDelete, nil, path, echo.MIMEApplicationJSON)
 	if err != nil {
 		return err
 	}
-	if change.Deleted || change.Doc.Get("trashed") == true {
-		// Doc deletion
-		res, err := CallRAGQuery(inst, http.MethodDelete, nil, fmt.Sprintf("/indexer/partition/%s/file/%s", inst.Domain, url.PathEscape(change.DocID)), echo.MIMEApplicationJSON)
-		if err != nil {
-			return err
-		}
-		defer res.Body.Close()
-		if res.StatusCode >= 500 {
-			return fmt.Errorf("DELETE status code: %d", res.StatusCode)
-		}
-	} else {
-		md5sum := fmt.Sprintf("%x", change.Doc.Get("md5sum"))
-		res, err := CallRAGQuery(inst, http.MethodGet, nil, fmt.Sprintf("/partition/%s/file/%s", inst.Domain, url.PathEscape(change.DocID)), echo.MIMEApplicationJSON)
-		if err != nil {
-			return err
-		}
-		defer res.Body.Close()
-
-		// When the content has not changed, there is no need to regenerate
-		// an embedding.
-		needIndexation := false
-		isNewFile := false
-		switch res.StatusCode {
-		case 200:
-			var response map[string]interface{}
-			if err = json.NewDecoder(res.Body).Decode(&response); err != nil {
-				return err
-			}
-			metadata, ok := response["metadata"].(map[string]interface{})
-			if !ok {
-				needIndexation = true
-			}
-			md5sumFromRAG, ok := metadata["md5sum"].(string)
-			if !ok {
-				needIndexation = true
-			}
-			needIndexation = md5sumFromRAG != md5sum
-
-		case 404:
-			needIndexation = true
-			isNewFile = true
-		default:
-			return fmt.Errorf("GET status code: %d", res.StatusCode)
-		}
-		dirID, _ := change.Doc.Get("dir_id").(string)
-		if !needIndexation {
-			// The content did not change but the file may have been
-			// moved/renamed: keep the knowledge-base workspaces in sync.
-			reconcileMembership(inst, logger, kb(), change.DocID, dirID)
-			return nil
-		}
-
-		name, _ := change.Doc.Get("name").(string)
-		mime, _ := change.Doc.Get("mime").(string)
-		metadataRaw, ok := change.Doc.Get("metadata").(map[string]interface{})
-		datetime := ""
-		if ok {
-			datetime, _ = metadataRaw["datetime"].(string)
-		}
-		internalID, _ := change.Doc.Get("internal_vfs_id").(string)
-		var content io.Reader
-
-		if mime == consts.NoteMimeType {
-			metadata, _ := change.Doc.Get("metadata").(map[string]interface{})
-			schema, _ := metadata["schema"].(map[string]interface{})
-			raw, _ := metadata["content"].(map[string]interface{})
-			noteDoc := &note.Document{
-				DocID:      change.DocID,
-				SchemaSpec: schema,
-				RawContent: raw,
-			}
-			md, err := noteDoc.Markdown(nil)
-			if err != nil {
-				return err
-			}
-			content = bytes.NewReader(md)
-			// See https://github.com/OpenLLM-France/RAGondin/issues/88
-			name = strings.TrimSuffix(name, consts.NoteExtension) + consts.MarkdownExtension
-		} else {
-			fs := inst.VFS()
-			fileDoc := &vfs.FileDoc{
-				Type:       consts.FileType,
-				DocID:      change.DocID,
-				DirID:      dirID,
-				DocName:    name,
-				InternalID: internalID,
-			}
-			f, err := fs.OpenFile(fileDoc)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-			content = f
-			if strings.HasSuffix(name, consts.DocsExtension) {
-				// See https://github.com/OpenLLM-France/RAGondin/issues/88
-				name = strings.TrimSuffix(name, consts.DocsExtension) + consts.MarkdownExtension
-			}
-		}
-
-		u.RawQuery = url.Values{
-			"dir_id": []string{dirID},
-			"name":   []string{name},
-			"md5sum": []string{md5sum},
-		}.Encode()
-		u.Path = fmt.Sprintf("/indexer/partition/%s/file/%s", inst.Domain, change.DocID)
-
-		// The streaming goroutine below needs the workspace membership, but
-		// kbContext is not safe for concurrent use: resolve it here, on the
-		// indexing loop, before the goroutine starts.
-		var workspaceIDsJSON string
-		attachUnknown := false
-		if kbc := kb(); !kbc.empty() {
-			if desired, ok := kbc.desiredFor(inst, dirID); !ok {
-				logger.Warnf("cannot resolve parent path for file %s (dir %s): skipping workspace attach", change.DocID, dirID)
-				attachUnknown = true
-			} else if len(desired) > 0 {
-				if wsJSON, err := json.Marshal(desired); err == nil {
-					workspaceIDsJSON = string(wsJSON)
-				}
-			}
-		}
-
-		// Create pipe and writer for file streaming
-		pr, pw := io.Pipe()
-		writer := multipart.NewWriter(pw)
-
-		go func() {
-			part, err := writer.CreateFormFile("file", name)
-			if err != nil {
-				_ = pw.CloseWithError(err)
-				return
-			}
-			if _, err := io.Copy(part, content); err != nil {
-				_ = pw.CloseWithError(err)
-				return
-			}
-
-			// No need to add filename here, it is already set through the file form
-			meta := map[string]string{
-				"md5sum":   md5sum,
-				"datetime": datetime,
-				"doctype":  doctype,
-			}
-			ragMetadata, err := json.Marshal(meta)
-			if err != nil {
-				_ = pw.CloseWithError(err)
-				return
-			}
-			if err := writer.WriteField("metadata", string(ragMetadata)); err != nil {
-				_ = pw.CloseWithError(err)
-				return
-			}
-			if workspaceIDsJSON != "" {
-				if err := writer.WriteField("workspace_ids", workspaceIDsJSON); err != nil {
-					_ = pw.CloseWithError(err)
-					return
-				}
-			}
-			defer pw.Close()
-			defer writer.Close()
-		}()
-
-		var req *http.Request
-		if isNewFile {
-			req, err = http.NewRequest(http.MethodPost, u.String(), pr)
-		} else {
-			req, err = http.NewRequest(http.MethodPut, u.String(), pr)
-		}
-		if err != nil {
-			return err
-		}
-
-		req.Header.Add(echo.HeaderAuthorization, "Bearer "+ragServer.APIKey)
-		req.Header.Add("Content-Type", writer.FormDataContentType())
-
-		res, err = ragHTTPClient.Do(req)
-		if err != nil {
-			return err
-		}
-
-		var response map[string]interface{}
-		if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
-			return err
-		}
-		defer res.Body.Close()
-
-		if res.StatusCode >= 500 {
-			return fmt.Errorf("Status code: %d", res.StatusCode)
-		}
-
-		if (!isNewFile || attachUnknown) && res.StatusCode < 300 {
-			// For an existing file, the content changed but it may also have
-			// been moved/renamed at the same time: keep the knowledge-base
-			// workspaces in sync after a successful re-upload. For a new file
-			// whose membership could not be resolved before the upload
-			// (attachUnknown), this is the only chance to attach it: retry
-			// now that the transient path-resolution error may have cleared.
-			reconcileMembership(inst, logger, kb(), change.DocID, dirID)
-		}
+	defer res.Body.Close()
+	if res.StatusCode >= 500 {
+		return fmt.Errorf("DELETE status code: %d", res.StatusCode)
 	}
 	return nil
+}
+
+// needsIndexation reports whether the file must be sent again. isNew tells
+// whether the RAG server knows it at all, which decides between a POST and a PUT.
+func needsIndexation(inst *instance.Instance, fileID, md5sum string) (needed, isNew bool, err error) {
+	indexed, known, err := indexedMD5Sum(inst.RAGServer(), inst.Domain, fileID)
+	if err != nil {
+		return false, false, err
+	}
+	if !known {
+		return true, true, nil
+	}
+	if indexed != md5sum {
+		return true, false, nil
+	}
+	// The RAG server holds this content, but a callback may never have come
+	// back to say so.
+	return !isIndexed(inst, fileID), false, nil
+}
+
+// indexedMD5Sum returns the md5sum the RAG server holds for the file. known is
+// false when it does not know the file at all, which decides between a POST
+// and a PUT.
+func indexedMD5Sum(server config.RAGServer, domain, fileID string) (md5sum string, known bool, err error) {
+	path := fmt.Sprintf("/partition/%s/file/%s", domain, url.PathEscape(fileID))
+	res, err := callRAG(server, http.MethodGet, nil, path, echo.MIMEApplicationJSON)
+	if err != nil {
+		return "", false, err
+	}
+	defer res.Body.Close()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		var response map[string]interface{}
+		if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
+			return "", false, err
+		}
+		metadata, _ := response["metadata"].(map[string]interface{})
+		md5sum, _ = metadata["md5sum"].(string)
+		return md5sum, true, nil
+	case http.StatusNotFound:
+		return "", false, nil
+	default:
+		return "", false, fmt.Errorf("GET status code: %d", res.StatusCode)
+	}
+}
+
+func isIndexed(inst *instance.Instance, docID string) bool {
+	var doc IndexStatus
+	if err := couchdb.GetDoc(inst, consts.ChatRAG, docID, &doc); err != nil {
+		return false
+	}
+	return doc.Indexed
+}
+
+func upsertToRAG(inst *instance.Instance, doctype string, change couchdb.Change, kb func() *kbContext, logger logger.Logger) error {
+	md5sum := decodeMD5Sum(change.Doc.Get("md5sum"))
+	needed, isNewFile, err := needsIndexation(inst, change.DocID, md5sum)
+	if err != nil {
+		return err
+	}
+
+	dirID, _ := change.Doc.Get("dir_id").(string)
+	if !needed {
+		// The content did not change but the file may have been
+		// moved/renamed: keep the knowledge-base workspaces in sync.
+		reconcileMembership(inst, logger, kb(), change.DocID, dirID)
+		return nil
+	}
+
+	name, content, err := resolveContent(inst, change)
+	if err != nil {
+		return err
+	}
+	defer content.Close()
+
+	// The streaming goroutine below needs the workspace membership, but
+	// kbContext is not safe for concurrent use: resolve it here, on the
+	// indexing loop, before the goroutine starts.
+	workspaceIDsJSON, attachUnknown := resolveWorkspaces(inst, logger, kb(), change.DocID, dirID)
+
+	datetime := ""
+	if metadata, ok := change.Doc.Get("metadata").(map[string]interface{}); ok {
+		datetime, _ = metadata["datetime"].(string)
+	}
+	rev, _ := change.Doc.Get("_rev").(string)
+	meta := map[string]string{
+		"md5sum":   md5sum,
+		"datetime": datetime,
+		"doctype":  doctype,
+		// Echoed back by the indexer on the callback, which is ordered on it.
+		"doc_rev": rev,
+	}
+
+	res, err := uploadToRAG(ragUpload{
+		Server:      inst.RAGServer(),
+		Domain:      inst.Domain,
+		FileID:      change.DocID,
+		Name:        name,
+		DirID:       dirID,
+		MD5Sum:      md5sum,
+		Meta:        meta,
+		Workspaces:  workspaceIDsJSON,
+		CallbackURL: inst.PageURL(IndexStatusPath, nil),
+		IsNew:       isNewFile,
+	}, content)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode >= 500 {
+		return fmt.Errorf("Status code: %d", res.StatusCode)
+	}
+
+	if (!isNewFile || attachUnknown) && res.StatusCode < 300 {
+		// For an existing file, the content changed but it may also have
+		// been moved/renamed at the same time: keep the knowledge-base
+		// workspaces in sync after a successful re-upload. For a new file
+		// whose membership could not be resolved before the upload
+		// (attachUnknown), this is the only chance to attach it: retry
+		// now that the transient path-resolution error may have cleared.
+		reconcileMembership(inst, logger, kb(), change.DocID, dirID)
+	}
+	return nil
+}
+
+// resolveWorkspaces returns the knowledge-base workspaces the file belongs to.
+// The boolean tells that they could not be resolved, which is not the same as
+// belonging to none.
+func resolveWorkspaces(inst *instance.Instance, logger logger.Logger, kbc *kbContext, fileID, dirID string) (string, bool) {
+	if kbc.empty() {
+		return "", false
+	}
+	desired, ok := kbc.desiredFor(inst, dirID)
+	if !ok {
+		logger.Warnf("cannot resolve parent path for file %s (dir %s): skipping workspace attach", fileID, dirID)
+		return "", true
+	}
+	if len(desired) == 0 {
+		return "", false
+	}
+	wsJSON, err := json.Marshal(desired)
+	if err != nil {
+		return "", false
+	}
+	return string(wsJSON), false
+}
+
+// resolveContent returns what to send to the RAG server. A note is sent as the
+// markdown it renders to, under a name given the markdown extension.
+func resolveContent(inst *instance.Instance, change couchdb.Change) (string, io.ReadCloser, error) {
+	name, _ := change.Doc.Get("name").(string)
+	mime, _ := change.Doc.Get("mime").(string)
+
+	if mime == consts.NoteMimeType {
+		metadata, _ := change.Doc.Get("metadata").(map[string]interface{})
+		schema, _ := metadata["schema"].(map[string]interface{})
+		raw, _ := metadata["content"].(map[string]interface{})
+		noteDoc := &note.Document{
+			DocID:      change.DocID,
+			SchemaSpec: schema,
+			RawContent: raw,
+		}
+		md, err := noteDoc.Markdown(nil)
+		if err != nil {
+			return "", nil, err
+		}
+		// See https://github.com/OpenLLM-France/RAGondin/issues/88
+		name = strings.TrimSuffix(name, consts.NoteExtension) + consts.MarkdownExtension
+		return name, io.NopCloser(bytes.NewReader(md)), nil
+	}
+
+	dirID, _ := change.Doc.Get("dir_id").(string)
+	internalID, _ := change.Doc.Get("internal_vfs_id").(string)
+	f, err := inst.VFS().OpenFile(&vfs.FileDoc{
+		Type:       consts.FileType,
+		DocID:      change.DocID,
+		DirID:      dirID,
+		DocName:    name,
+		InternalID: internalID,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+	if strings.HasSuffix(name, consts.DocsExtension) {
+		// See https://github.com/OpenLLM-France/RAGondin/issues/88
+		name = strings.TrimSuffix(name, consts.DocsExtension) + consts.MarkdownExtension
+	}
+	return name, f, nil
+}
+
+// ragUpload is what the RAG server needs to index one file.
+type ragUpload struct {
+	Server      config.RAGServer
+	Domain      string
+	FileID      string
+	Name        string
+	DirID       string
+	MD5Sum      string
+	Meta        map[string]string
+	Workspaces  string
+	CallbackURL string
+	IsNew       bool
+}
+
+func uploadToRAG(up ragUpload, content io.Reader) (*http.Response, error) {
+	u, err := url.Parse(up.Server.URL)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = fmt.Sprintf("/indexer/partition/%s/file/%s", up.Domain, up.FileID)
+	u.RawQuery = url.Values{
+		"dir_id": []string{up.DirID},
+		"name":   []string{up.Name},
+		"md5sum": []string{up.MD5Sum},
+	}.Encode()
+
+	pr, pw := io.Pipe()
+	writer := multipart.NewWriter(pw)
+	go func() {
+		defer pw.Close()
+		defer writer.Close()
+
+		part, err := writer.CreateFormFile("file", up.Name)
+		if err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		if _, err := io.Copy(part, content); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		// No need to add filename here, it is already set through the file form
+		ragMetadata, err := json.Marshal(up.Meta)
+		if err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		fields := map[string]string{
+			"metadata":     string(ragMetadata),
+			"callback_url": up.CallbackURL,
+		}
+		if up.Workspaces != "" {
+			fields["workspace_ids"] = up.Workspaces
+		}
+		for field, value := range fields {
+			if err := writer.WriteField(field, value); err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
+		}
+	}()
+
+	method := http.MethodPut
+	if up.IsNew {
+		method = http.MethodPost
+	}
+	req, err := http.NewRequest(method, u.String(), pr)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add(echo.HeaderAuthorization, "Bearer "+up.Server.APIKey)
+	req.Header.Add("Content-Type", writer.FormDataContentType())
+	return ragHTTPClient.Do(req)
+}
+
+const md5Length = 16
+
+// decodeMD5Sum turns the md5sum carried by the changes feed into the
+// hexadecimal digest the RAG server is given. CouchDB serializes the bytes of
+// the digest in base64.
+func decodeMD5Sum(v interface{}) string {
+	s, _ := v.(string)
+	if s == "" {
+		return ""
+	}
+	if raw, err := hex.DecodeString(s); err == nil && len(raw) == md5Length {
+		return strings.ToLower(s)
+	}
+	raw, err := base64.StdEncoding.DecodeString(s)
+	if err != nil || len(raw) != md5Length {
+		return ""
+	}
+	return hex.EncodeToString(raw)
 }
 
 // getLastSeqNumber returns the last sequence number of the previous

--- a/model/rag/index_http_test.go
+++ b/model/rag/index_http_test.go
@@ -1,11 +1,12 @@
 package rag
 
 import (
+	"bytes"
 	"encoding/json"
-	"io"
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -13,24 +14,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// formFields reads back the multipart body the RAG server received.
-func formFields(t *testing.T, contentType string, body []byte) map[string]string {
+// formFields reads back the multipart body the RAG server received. ReadForm
+// keeps the file part out of Value, so only the fields are returned.
+func formFields(t *testing.T, contentType string, body []byte) url.Values {
 	t.Helper()
 	_, params, err := mime.ParseMediaType(contentType)
 	require.NoError(t, err)
-	reader := multipart.NewReader(strings.NewReader(string(body)), params["boundary"])
 
-	fields := map[string]string{}
-	for {
-		part, err := reader.NextPart()
-		if err == io.EOF {
-			return fields
-		}
-		require.NoError(t, err)
-		content, err := io.ReadAll(part)
-		require.NoError(t, err)
-		fields[part.FormName()] = string(content)
-	}
+	form, err := multipart.NewReader(bytes.NewReader(body), params["boundary"]).ReadForm(int64(len(body)))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = form.RemoveAll() })
+	return form.Value
 }
 
 func TestUploadToRAG(t *testing.T) {
@@ -62,10 +56,10 @@ func TestUploadToRAG(t *testing.T) {
 		})
 
 		fields := formFields(t, contentType, req.Body)
-		assert.Equal(t, "https://alice.example.net/ai/index/status", fields["callback_url"])
+		assert.Equal(t, "https://alice.example.net/ai/index/status", fields.Get("callback_url"))
 
 		var meta map[string]string
-		require.NoError(t, json.Unmarshal([]byte(fields["metadata"]), &meta))
+		require.NoError(t, json.Unmarshal([]byte(fields.Get("metadata")), &meta))
 		assert.Equal(t, "3-abc", meta["doc_rev"])
 		assert.Equal(t, "io.cozy.files", meta["doctype"])
 	})
@@ -84,7 +78,7 @@ func TestUploadToRAG(t *testing.T) {
 		assert.NotContains(t, formFields(t, contentType, req.Body), "workspace_ids")
 
 		req, contentType = upload(t, ragUpload{FileID: "a1b2c3", Name: "note.txt", Workspaces: `["ws1"]`})
-		assert.Equal(t, `["ws1"]`, formFields(t, contentType, req.Body)["workspace_ids"])
+		assert.Equal(t, `["ws1"]`, formFields(t, contentType, req.Body).Get("workspace_ids"))
 	})
 }
 

--- a/model/rag/index_http_test.go
+++ b/model/rag/index_http_test.go
@@ -1,0 +1,160 @@
+package rag
+
+import (
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// formFields reads back the multipart body the RAG server received.
+func formFields(t *testing.T, contentType string, body []byte) map[string]string {
+	t.Helper()
+	_, params, err := mime.ParseMediaType(contentType)
+	require.NoError(t, err)
+	reader := multipart.NewReader(strings.NewReader(string(body)), params["boundary"])
+
+	fields := map[string]string{}
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			return fields
+		}
+		require.NoError(t, err)
+		content, err := io.ReadAll(part)
+		require.NoError(t, err)
+		fields[part.FormName()] = string(content)
+	}
+}
+
+func TestUploadToRAG(t *testing.T) {
+	upload := func(t *testing.T, up ragUpload) (recordedRequest, string) {
+		t.Helper()
+		var contentType string
+		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			contentType = req.Header.Get("Content-Type")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		})
+		up.Server = server
+		up.Domain = "alice.example.net"
+		res, err := uploadToRAG(up, strings.NewReader("hello"))
+		require.NoError(t, err)
+		defer res.Body.Close()
+		requests := rec.all()
+		require.Len(t, requests, 1)
+		return requests[0], contentType
+	}
+
+	t.Run("the callback URL and the file revision reach the RAG server", func(t *testing.T) {
+		req, contentType := upload(t, ragUpload{
+			FileID:      "a1b2c3",
+			Name:        "note.txt",
+			MD5Sum:      "098f6bcd4621d373cade4e832627b4f6",
+			Meta:        map[string]string{"doc_rev": "3-abc", "doctype": "io.cozy.files"},
+			CallbackURL: "https://alice.example.net/ai/index/status",
+		})
+
+		fields := formFields(t, contentType, req.Body)
+		assert.Equal(t, "https://alice.example.net/ai/index/status", fields["callback_url"])
+
+		var meta map[string]string
+		require.NoError(t, json.Unmarshal([]byte(fields["metadata"]), &meta))
+		assert.Equal(t, "3-abc", meta["doc_rev"])
+		assert.Equal(t, "io.cozy.files", meta["doctype"])
+	})
+
+	t.Run("a known file is sent with a PUT, a new one with a POST", func(t *testing.T) {
+		req, _ := upload(t, ragUpload{FileID: "a1b2c3", Name: "note.txt", IsNew: false})
+		assert.Equal(t, http.MethodPut, req.Method)
+		assert.Equal(t, "/indexer/partition/alice.example.net/file/a1b2c3", req.Path)
+
+		req, _ = upload(t, ragUpload{FileID: "a1b2c3", Name: "note.txt", IsNew: true})
+		assert.Equal(t, http.MethodPost, req.Method)
+	})
+
+	t.Run("workspaces are only sent when the file belongs to some", func(t *testing.T) {
+		req, contentType := upload(t, ragUpload{FileID: "a1b2c3", Name: "note.txt"})
+		assert.NotContains(t, formFields(t, contentType, req.Body), "workspace_ids")
+
+		req, contentType = upload(t, ragUpload{FileID: "a1b2c3", Name: "note.txt", Workspaces: `["ws1"]`})
+		assert.Equal(t, `["ws1"]`, formFields(t, contentType, req.Body)["workspace_ids"])
+	})
+}
+
+func TestDeleteFromRAGHTTP(t *testing.T) {
+	t.Run("the file is deleted from its partition", func(t *testing.T) {
+		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		require.NoError(t, deleteFromRAGHTTP(server, "alice.example.net", "a1b2c3"))
+
+		requests := rec.all()
+		require.Len(t, requests, 1)
+		assert.Equal(t, http.MethodDelete, requests[0].Method)
+		assert.Equal(t, "/indexer/partition/alice.example.net/file/a1b2c3", requests[0].Path)
+	})
+
+	t.Run("a file the RAG server does not know is not an error", func(t *testing.T) {
+		server, _ := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+		assert.NoError(t, deleteFromRAGHTTP(server, "alice.example.net", "a1b2c3"))
+	})
+
+	t.Run("a server error is reported so the job is retried", func(t *testing.T) {
+		server, _ := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		assert.Error(t, deleteFromRAGHTTP(server, "alice.example.net", "a1b2c3"))
+	})
+}
+
+func TestIndexedMD5Sum(t *testing.T) {
+	t.Run("the md5sum the RAG server holds is returned", func(t *testing.T) {
+		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"metadata":{"md5sum":"098f6bcd4621d373cade4e832627b4f6"}}`))
+		})
+		md5sum, known, err := indexedMD5Sum(server, "alice.example.net", "a1b2c3")
+		require.NoError(t, err)
+		assert.True(t, known)
+		assert.Equal(t, "098f6bcd4621d373cade4e832627b4f6", md5sum)
+		assert.Equal(t, "/partition/alice.example.net/file/a1b2c3", rec.all()[0].Path)
+	})
+
+	t.Run("an unknown file is reported as such rather than as an error", func(t *testing.T) {
+		server, _ := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+		md5sum, known, err := indexedMD5Sum(server, "alice.example.net", "a1b2c3")
+		require.NoError(t, err)
+		assert.False(t, known)
+		assert.Empty(t, md5sum)
+	})
+
+	t.Run("a file with no metadata is known with no md5sum", func(t *testing.T) {
+		server, _ := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		})
+		md5sum, known, err := indexedMD5Sum(server, "alice.example.net", "a1b2c3")
+		require.NoError(t, err)
+		assert.True(t, known)
+		assert.Empty(t, md5sum)
+	})
+
+	t.Run("a server error is reported", func(t *testing.T) {
+		server, _ := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		_, _, err := indexedMD5Sum(server, "alice.example.net", "a1b2c3")
+		assert.Error(t, err)
+	})
+}

--- a/model/rag/index_test.go
+++ b/model/rag/index_test.go
@@ -1,0 +1,69 @@
+package rag
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/feature"
+	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecodeMD5SumFromFileDoc pins the contract decodeMD5Sum relies on: a
+// FileDoc serializes its digest the way the changes feed then carries it, and
+// decoding that gives back the hexadecimal digest the RAG server is given.
+func TestDecodeMD5SumFromFileDoc(t *testing.T) {
+	// The md5sum of "test".
+	sum := []byte{0x09, 0x8f, 0x6b, 0xcd, 0x46, 0x21, 0xd3, 0x73,
+		0xca, 0xde, 0x4e, 0x83, 0x26, 0x27, 0xb4, 0xf6}
+
+	raw, err := json.Marshal(&vfs.FileDoc{MD5Sum: sum})
+	require.NoError(t, err)
+
+	var doc map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &doc))
+
+	assert.Equal(t, fmt.Sprintf("%x", sum), decodeMD5Sum(doc["md5sum"]))
+}
+
+func TestDecodeMD5Sum(t *testing.T) {
+	const (
+		hexSum    = "098f6bcd4621d373cade4e832627b4f6"
+		base64Sum = "CY9rzUYh03PK3k6DJie09g=="
+	)
+
+	// What the changes feed carries: CouchDB serializes the digest bytes in
+	// base64.
+	assert.Equal(t, hexSum, decodeMD5Sum(base64Sum))
+
+	assert.Equal(t, hexSum, decodeMD5Sum(hexSum))
+	assert.Equal(t, hexSum, decodeMD5Sum("098F6BCD4621D373CADE4E832627B4F6"))
+
+	assert.Equal(t, "", decodeMD5Sum(""))
+	assert.Equal(t, "", decodeMD5Sum(nil))
+	assert.Equal(t, "", decodeMD5Sum("not a digest"))
+	assert.Equal(t, "", decodeMD5Sum("dG9vIHNob3J0"))     // valid base64, 9 bytes
+	assert.Equal(t, "", decodeMD5Sum(map[string]int{}))   // not even a string
+	assert.Equal(t, "", decodeMD5Sum("098f6bcd4621d373")) // valid hex, 8 bytes
+}
+
+func TestIsClassAllowed(t *testing.T) {
+	off := &feature.Flags{M: map[string]interface{}{}}
+	on := &feature.Flags{M: map[string]interface{}{
+		"rag.index.image.enabled": true,
+		"rag.index.video.enabled": true,
+		"rag.index.audio.enabled": true,
+	}}
+
+	// Text-based files do not depend on any flag.
+	assert.True(t, isClassAllowed(off, "text"))
+	assert.True(t, isClassAllowed(off, ""))
+
+	for _, class := range []string{consts.ImageClass, consts.VideoClass, consts.AudioClass} {
+		assert.False(t, isClassAllowed(off, class), class)
+		assert.True(t, isClassAllowed(on, class), class)
+	}
+}

--- a/model/rag/index_test.go
+++ b/model/rag/index_test.go
@@ -39,15 +39,11 @@ func TestDecodeMD5Sum(t *testing.T) {
 	// base64.
 	assert.Equal(t, hexSum, decodeMD5Sum(base64Sum))
 
-	assert.Equal(t, hexSum, decodeMD5Sum(hexSum))
-	assert.Equal(t, hexSum, decodeMD5Sum("098F6BCD4621D373CADE4E832627B4F6"))
-
 	assert.Equal(t, "", decodeMD5Sum(""))
 	assert.Equal(t, "", decodeMD5Sum(nil))
 	assert.Equal(t, "", decodeMD5Sum("not a digest"))
-	assert.Equal(t, "", decodeMD5Sum("dG9vIHNob3J0"))     // valid base64, 9 bytes
-	assert.Equal(t, "", decodeMD5Sum(map[string]int{}))   // not even a string
-	assert.Equal(t, "", decodeMD5Sum("098f6bcd4621d373")) // valid hex, 8 bytes
+	assert.Equal(t, "", decodeMD5Sum("dG9vIHNob3J0"))   // valid base64, 9 bytes
+	assert.Equal(t, "", decodeMD5Sum(map[string]int{})) // not even a string
 }
 
 func TestIsClassAllowed(t *testing.T) {

--- a/model/rag/status.go
+++ b/model/rag/status.go
@@ -70,6 +70,20 @@ func SetIndexStatus(inst *instance.Instance, docID, newStatus, rev string, times
 	return couchdb.Upsert(inst, doc)
 }
 
+// DeleteIndexStatus removes the indexation status of a document. One that never
+// had a status is not an error.
+func DeleteIndexStatus(inst *instance.Instance, docID string) error {
+	var doc IndexStatus
+	err := couchdb.GetDoc(inst, consts.ChatRAG, docID, &doc)
+	if err != nil {
+		if couchdb.IsNotFoundError(err) || couchdb.IsNoDatabaseError(err) {
+			return nil
+		}
+		return err
+	}
+	return couchdb.DeleteDoc(inst, &doc)
+}
+
 // isOutdated reports whether a callback is older than the stored status. Two
 // callbacks about the same revision describe the same indexation, so the last
 // one is kept.

--- a/model/rag/status.go
+++ b/model/rag/status.go
@@ -23,19 +23,25 @@ const (
 // callback_url given to the indexer.
 const IndexStatusPath = "/ai/index/status"
 
-func SetIndexStatus(inst *instance.Instance, docID, newStatus, rev string, timestamp time.Time) error {
-	if timestamp.IsZero() {
-		timestamp = time.Now()
-	}
-	log := inst.Logger().WithNamespace("rag")
-
-	// couchdb.Upsert overwrites the revision it finds instead of raising a
-	// conflict, so every read this decision rests on must be under the lock.
+// lockIndexStatus guards the read-check-write of a status document.
+// couchdb.Upsert overwrites the revision it finds instead of raising a conflict,
+// so a caller that decides from what it read must hold this lock until it writes.
+func lockIndexStatus(inst *instance.Instance, docID string) (func(), error) {
 	mu := config.Lock().ReadWrite(inst, "rag/index-status/"+docID)
 	if err := mu.Lock(); err != nil {
+		return nil, err
+	}
+	return mu.Unlock, nil
+}
+
+func SetIndexStatus(inst *instance.Instance, docID, newStatus, rev string) error {
+	log := inst.Logger().WithNamespace("rag")
+
+	unlock, err := lockIndexStatus(inst, docID)
+	if err != nil {
 		return err
 	}
-	defer mu.Unlock()
+	defer unlock()
 
 	// A missing file is a no-op: it may have been deleted before its callback.
 	file, err := inst.VFS().FileByID(docID)
@@ -66,15 +72,21 @@ func SetIndexStatus(inst *instance.Instance, docID, newStatus, rev string, times
 	}
 
 	doc.DocRev = rev
-	applyStatus(doc, newStatus, timestamp)
+	applyStatus(doc, newStatus)
 	return couchdb.Upsert(inst, doc)
 }
 
 // DeleteIndexStatus removes the indexation status of a document. One that never
 // had a status is not an error.
 func DeleteIndexStatus(inst *instance.Instance, docID string) error {
+	unlock, err := lockIndexStatus(inst, docID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
 	var doc IndexStatus
-	err := couchdb.GetDoc(inst, consts.ChatRAG, docID, &doc)
+	err = couchdb.GetDoc(inst, consts.ChatRAG, docID, &doc)
 	if err != nil {
 		if couchdb.IsNotFoundError(err) || couchdb.IsNoDatabaseError(err) {
 			return nil
@@ -94,14 +106,15 @@ func isOutdated(rev, storedRev string) bool {
 	return revision.Generation(rev) < revision.Generation(storedRev)
 }
 
-func applyStatus(doc *IndexStatus, newStatus string, timestamp time.Time) {
+func applyStatus(doc *IndexStatus, newStatus string) {
+	now := time.Now()
 	doc.Status = newStatus
 	switch newStatus {
 	case StatusSuccess:
 		doc.Indexed = true
-		doc.LastSuccessDate = &timestamp
+		doc.LastSuccessDate = &now
 	case StatusError:
 		// Indexed is preserved: stays true if the file was previously indexed.
-		doc.LastErrorDate = &timestamp
+		doc.LastErrorDate = &now
 	}
 }

--- a/model/rag/status_test.go
+++ b/model/rag/status_test.go
@@ -2,45 +2,42 @@ package rag
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestApplyStatus(t *testing.T) {
-	t1 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
-
 	t.Run("success sets Indexed=true and LastSuccessDate", func(t *testing.T) {
 		doc := NewIndexStatus("a1b2c3")
-		applyStatus(doc, StatusSuccess, t1)
+		applyStatus(doc, StatusSuccess)
 		assert.True(t, doc.Indexed)
 		assert.Equal(t, StatusSuccess, doc.Status)
-		assert.Equal(t, t1, *doc.LastSuccessDate)
+		assert.NotNil(t, doc.LastSuccessDate)
 		assert.Nil(t, doc.LastErrorDate)
 	})
 
 	t.Run("error without prior success keeps Indexed=false", func(t *testing.T) {
 		doc := NewIndexStatus("a1b2c3")
-		applyStatus(doc, StatusError, t1)
+		applyStatus(doc, StatusError)
 		assert.False(t, doc.Indexed)
 		assert.Equal(t, StatusError, doc.Status)
-		assert.Equal(t, t1, *doc.LastErrorDate)
+		assert.NotNil(t, doc.LastErrorDate)
 		assert.Nil(t, doc.LastSuccessDate)
 	})
 
 	t.Run("error after success preserves Indexed=true", func(t *testing.T) {
 		doc := NewIndexStatus("a1b2c3")
 		doc.Indexed = true
-		applyStatus(doc, StatusError, t1)
+		applyStatus(doc, StatusError)
 		assert.True(t, doc.Indexed)
 		assert.Equal(t, StatusError, doc.Status)
-		assert.Equal(t, t1, *doc.LastErrorDate)
+		assert.NotNil(t, doc.LastErrorDate)
 	})
 
 	t.Run("notsupported only sets Status", func(t *testing.T) {
 		doc := NewIndexStatus("a1b2c3")
 		doc.Indexed = true
-		applyStatus(doc, StatusNotSupported, t1)
+		applyStatus(doc, StatusNotSupported)
 		assert.True(t, doc.Indexed)
 		assert.Equal(t, StatusNotSupported, doc.Status)
 		assert.Nil(t, doc.LastSuccessDate)

--- a/web/ai/index_status.go
+++ b/web/ai/index_status.go
@@ -18,9 +18,8 @@ type statusMessage struct {
 	DocID     string `json:"file_id"`
 	Status    string `json:"status"`    // "success" | "error" | "notsupported"
 	Timestamp string `json:"timestamp"` // RFC3339Nano
-	// The indexer echoes back the metadata it was given; only the revision of
-	// the document the status is about is read. Callbacks are ordered on it.
-	Metadata struct {
+	Metadata  struct {
+		// The _rev of the io.cozy.files document when it was sent for indexation.
 		DocRev string `json:"doc_rev"`
 	} `json:"metadata"`
 }

--- a/web/ai/index_status.go
+++ b/web/ai/index_status.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/cozy/cozy-stack/model/rag"
 	"github.com/cozy/cozy-stack/pkg/jsonapi"
@@ -16,8 +15,7 @@ import (
 type statusMessage struct {
 	Partition string `json:"partition"`
 	DocID     string `json:"file_id"`
-	Status    string `json:"status"`    // "success" | "error" | "notsupported"
-	Timestamp string `json:"timestamp"` // RFC3339Nano
+	Status    string `json:"status"` // "success" | "error" | "notsupported"
 	Metadata  struct {
 		// The _rev of the io.cozy.files document when it was sent for indexation.
 		DocRev string `json:"doc_rev"`
@@ -66,22 +64,9 @@ func IndexStatus(c echo.Context) error {
 		return badRequest(fmt.Errorf("unknown status %q for doc %s", msg.Status, msg.DocID))
 	}
 
-	var ts time.Time
-	if msg.Timestamp != "" {
-		var err error
-		ts, err = time.Parse(time.RFC3339Nano, msg.Timestamp)
-		if err != nil {
-			log.Warnf("index status: invalid timestamp %q for doc %s, using now", msg.Timestamp, msg.DocID)
-			ts = time.Now()
-		}
-	} else {
-		log.Warnf("index status: missing timestamp for doc %s, using now", msg.DocID)
-		ts = time.Now()
-	}
+	log.Debugf("index status: doc %s status=%s", msg.DocID, msg.Status)
 
-	log.Debugf("index status: doc %s status=%s ts=%s", msg.DocID, msg.Status, ts)
-
-	if err := rag.SetIndexStatus(inst, msg.DocID, msg.Status, msg.Metadata.DocRev, ts); err != nil {
+	if err := rag.SetIndexStatus(inst, msg.DocID, msg.Status, msg.Metadata.DocRev); err != nil {
 		// The indexer does not replay a failed callback: this status is lost.
 		log.Errorf("index status: cannot save status=%s for doc %s: %s", msg.Status, msg.DocID, err)
 		return jsonapi.InternalServerError(err)

--- a/web/ai/index_status_test.go
+++ b/web/ai/index_status_test.go
@@ -49,12 +49,10 @@ func TestIndexStatus(t *testing.T) {
 		doc := createStatusTestFile(t, fs, "rag-success.txt")
 		defer destroyStatusTestFile(t, fs, doc)
 
-		at := time.Now().UTC().Truncate(time.Second)
 		postStatus(t, map[string]interface{}{
 			"partition": inst.Domain,
 			"file_id":   doc.DocID,
 			"status":    "success",
-			"timestamp": at.Format(time.RFC3339Nano),
 			"metadata":  map[string]interface{}{"doc_rev": doc.Rev()},
 		}).Status(204)
 
@@ -74,7 +72,6 @@ func TestIndexStatus(t *testing.T) {
 			"partition": inst.Domain,
 			"file_id":   doc.DocID,
 			"status":    "success",
-			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
 			"metadata":  map[string]interface{}{"doc_rev": doc.Rev()},
 		}).Status(204)
 
@@ -93,12 +90,10 @@ func TestIndexStatus(t *testing.T) {
 		doc := createStatusTestFile(t, fs, "rag-error.txt")
 		defer destroyStatusTestFile(t, fs, doc)
 
-		at := time.Now().UTC().Truncate(time.Second)
 		postStatus(t, map[string]interface{}{
 			"partition": inst.Domain,
 			"file_id":   doc.DocID,
 			"status":    "error",
-			"timestamp": at.Format(time.RFC3339Nano),
 			"metadata":  map[string]interface{}{"doc_rev": doc.Rev()},
 		}).Status(204)
 
@@ -114,12 +109,10 @@ func TestIndexStatus(t *testing.T) {
 		doc := createStatusTestFile(t, fs, "rag-notsupported.txt")
 		defer destroyStatusTestFile(t, fs, doc)
 
-		now := time.Now().UTC()
 		postStatus(t, map[string]interface{}{
 			"partition": inst.Domain,
 			"file_id":   doc.DocID,
 			"status":    "success",
-			"timestamp": now.Add(-time.Hour).Format(time.RFC3339Nano),
 			"metadata":  map[string]interface{}{"doc_rev": "3-" + strings.Repeat("a", 32)},
 		}).Status(204)
 
@@ -127,7 +120,6 @@ func TestIndexStatus(t *testing.T) {
 			"partition": inst.Domain,
 			"file_id":   doc.DocID,
 			"status":    "notsupported",
-			"timestamp": now.Format(time.RFC3339Nano),
 			"metadata":  map[string]interface{}{"doc_rev": "4-" + strings.Repeat("b", 32)},
 		}).Status(204)
 
@@ -148,7 +140,6 @@ func TestIndexStatus(t *testing.T) {
 			"partition": inst.Domain,
 			"file_id":   doc.DocID,
 			"status":    "success",
-			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
 			"metadata":  map[string]interface{}{"doc_rev": "5-" + strings.Repeat("a", 32)},
 		}).Status(204)
 
@@ -159,7 +150,6 @@ func TestIndexStatus(t *testing.T) {
 			"partition": inst.Domain,
 			"file_id":   doc.DocID,
 			"status":    "error",
-			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
 			"metadata":  map[string]interface{}{"doc_rev": "3-" + strings.Repeat("b", 32)},
 		}).Status(204)
 
@@ -178,7 +168,6 @@ func TestIndexStatus(t *testing.T) {
 			"partition": inst.Domain,
 			"file_id":   doc.DocID,
 			"status":    "success",
-			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
 			"metadata":  map[string]interface{}{"doc_rev": doc.Rev()},
 		}).Status(204)
 
@@ -217,37 +206,6 @@ func TestIndexStatus(t *testing.T) {
 			"status":    "success",
 			"metadata":  map[string]interface{}{"doc_rev": "1-abc"},
 		}).Status(400)
-	})
-
-	t.Run("missing timestamp falls back to now", func(t *testing.T) {
-		fs := inst.VFS()
-		doc := createStatusTestFile(t, fs, "rag-no-ts.txt")
-		defer destroyStatusTestFile(t, fs, doc)
-
-		postStatus(t, map[string]interface{}{
-			"partition": inst.Domain,
-			"file_id":   doc.DocID,
-			"status":    "success",
-			"metadata":  map[string]interface{}{"doc_rev": doc.Rev()},
-		}).Status(204)
-
-		require.NotNil(t, getStatus(t, inst, doc.DocID).LastSuccessDate)
-	})
-
-	t.Run("malformed timestamp falls back to now", func(t *testing.T) {
-		fs := inst.VFS()
-		doc := createStatusTestFile(t, fs, "rag-bad-ts.txt")
-		defer destroyStatusTestFile(t, fs, doc)
-
-		postStatus(t, map[string]interface{}{
-			"partition": inst.Domain,
-			"file_id":   doc.DocID,
-			"status":    "success",
-			"timestamp": "not-a-date",
-			"metadata":  map[string]interface{}{"doc_rev": doc.Rev()},
-		}).Status(204)
-
-		require.NotNil(t, getStatus(t, inst, doc.DocID).LastSuccessDate)
 	})
 
 	t.Run("non-existent file_id is a no-op", func(t *testing.T) {


### PR DESCRIPTION

callRAGIndexer was a 253-line function; it is now a 35-line dispatch that delegates. 

The indexer is given the callback URL to report the indexation status on, and the revision of the file it is about, which it echoes back. A file is indexed again when its status says it is not, so that a status lost while the file was being indexed is recovered. Its status document is deleted along with the file, and a class the flags refuse is recorded as notsupported.

The md5sum sent to the indexer was the hexadecimal encoding of a base64 string, and is now the digest itself.