### PR TITLE
fix(rabbitmq): wait for managers before test publish

### DIFF
--- a/pkg/rabbitmq/service_test.go
+++ b/pkg/rabbitmq/service_test.go
@@ -101,8 +101,11 @@ func TestRabbitMQService(t *testing.T) {
 		svc, err := rabbitmq.NewService(cfg)
 		require.NoError(t, err)
 
-		_, err = svc.StartManagers()
+		managers, err := svc.StartManagers()
 		require.NoError(t, err)
+		for _, manager := range managers {
+			require.NoError(t, manager.WaitReady(testCtx(t)))
+		}
 
 		slug, domain := inst.SlugAndDomain()
 


### PR DESCRIPTION
## Summary

- wait for RabbitMQ manager topology before publishing integration-test messages
- validate the focused message test and the complete parallel TestRabbitMQService test
- broader short package validation is blocked locally by existing macOS Docker TLS bind-mount errors