### PR TITLE
fix(permissions): prevent duplicate share tokens

### DIFF
--- a/model/instance/instance.go
+++ b/model/instance/instance.go
@@ -799,6 +799,10 @@ func (i *Instance) PickKey(audience string) ([]byte, error) {
 
 // MakeJWT is a shortcut to create a JWT
 func (i *Instance) MakeJWT(audience, subject, scope, sessionID string, issuedAt time.Time) (string, error) {
+	return i.makeJWT(audience, subject, scope, sessionID, "", issuedAt)
+}
+
+func (i *Instance) makeJWT(audience, subject, scope, sessionID, tokenID string, issuedAt time.Time) (string, error) {
 	secret, err := i.PickKey(audience)
 	if err != nil {
 		return "", err
@@ -806,6 +810,7 @@ func (i *Instance) MakeJWT(audience, subject, scope, sessionID string, issuedAt 
 	return crypto.NewJWT(secret, permission.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Audience: jwt.ClaimStrings{audience},
+			ID:       tokenID,
 			Issuer:   i.Domain,
 			IssuedAt: jwt.NewNumericDate(issuedAt),
 			Subject:  subject,
@@ -838,12 +843,11 @@ func (i *Instance) BuildKonnectorToken(slug string) string {
 	return token
 }
 
-// CreateShareCode returns a new sharecode to put the codes field of a
-// permissions document
-func (i *Instance) CreateShareCode(subject string) (string, error) {
+// CreateShareCode returns a new sharecode tied to a permissions document by its JWT ID.
+func (i *Instance) CreateShareCode(subject, permissionID string) (string, error) {
 	scope := ""
 	sessionID := ""
-	return i.MakeJWT(consts.ShareAudience, subject, scope, sessionID, time.Now())
+	return i.makeJWT(consts.ShareAudience, subject, scope, sessionID, permissionID, time.Now())
 }
 
 // MovedError is used to return an error when the instance has been moved to a

--- a/model/move/importer.go
+++ b/model/move/importer.go
@@ -518,7 +518,7 @@ func (im *importer) importPermission(zf *zip.File) error {
 	}
 	// We need to remake the long codes with the new instance domain
 	for name := range doc.Codes {
-		longcode, err := im.inst.CreateShareCode(name)
+		longcode, err := im.inst.CreateShareCode(name, doc.ID())
 		if err != nil {
 			return err
 		}

--- a/model/permission/permissions.go
+++ b/model/permission/permissions.go
@@ -765,6 +765,7 @@ func CreateShareSet(
 	}
 	// SourceID stays the same, allow quick destruction of all children permissions
 	doc := &Permission{
+		PID:         subdoc.PID,
 		Type:        TypeShareByLink,
 		SourceID:    sourceID,
 		Permissions: set,
@@ -782,7 +783,12 @@ func CreateShareSet(
 		doc.Password = hash
 	}
 
-	err := couchdb.CreateDoc(db, doc)
+	var err error
+	if doc.ID() == "" {
+		err = couchdb.CreateDoc(db, doc)
+	} else {
+		err = couchdb.CreateNamedDocWithDB(db, doc)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -793,6 +799,7 @@ func CreateShareSet(
 // CreateSharePreviewSet creates a Permission doc for previewing a sharing
 func CreateSharePreviewSet(db prefixer.Prefixer, sharingID string, codes, shortcodes map[string]string, subdoc Permission) (*Permission, error) {
 	doc := &Permission{
+		PID:         subdoc.PID,
 		Type:        TypeSharePreview,
 		Permissions: subdoc.Permissions,
 		Codes:       codes,
@@ -800,7 +807,12 @@ func CreateSharePreviewSet(db prefixer.Prefixer, sharingID string, codes, shortc
 		SourceID:    consts.Sharings + "/" + sharingID,
 		Metadata:    subdoc.Metadata,
 	}
-	err := couchdb.CreateDoc(db, doc)
+	var err error
+	if doc.ID() == "" {
+		err = couchdb.CreateDoc(db, doc)
+	} else {
+		err = couchdb.CreateNamedDocWithDB(db, doc)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/model/sharing/sharing.go
+++ b/model/sharing/sharing.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/pkg/realtime"
 	"github.com/cozy/cozy-stack/pkg/utils"
+	"github.com/gofrs/uuid/v5"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/labstack/echo/v4"
 )
@@ -301,6 +302,16 @@ func (s *Sharing) BeOwner(inst *instance.Instance, slug string) error {
 // or updates it with the new codes if the document already exists
 func (s *Sharing) CreatePreviewPermissions(inst *instance.Instance) (*permission.Permission, error) {
 	doc, _ := permission.GetForSharePreview(inst, s.SID)
+	permissionID := ""
+	if doc == nil {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return nil, err
+		}
+		permissionID = id.String()
+	} else {
+		permissionID = doc.ID()
+	}
 
 	codes := make(map[string]string, len(s.Members)-1)
 	shortcodes := make(map[string]string, len(s.Members)-1)
@@ -329,7 +340,7 @@ func (s *Sharing) CreatePreviewPermissions(inst *instance.Instance) (*permission
 		if !okCode {
 			// Use a scoped subject to avoid generating identical share codes
 			// for different permission types or sharings within the same second.
-			codes[key], err = inst.CreateShareCode("preview:" + s.SID + ":" + key)
+			codes[key], err = inst.CreateShareCode("preview:"+s.SID+":"+key, permissionID)
 			if err != nil {
 				return nil, err
 			}
@@ -359,6 +370,7 @@ func (s *Sharing) CreatePreviewPermissions(inst *instance.Instance) (*permission
 		md := metadata.New()
 		md.CreatedByApp = s.AppSlug
 		subdoc := permission.Permission{
+			PID:         permissionID,
 			Permissions: set,
 			Metadata:    md,
 		}
@@ -432,7 +444,7 @@ func (s *Sharing) GetInteractCode(inst *instance.Instance, member *Member, membe
 		key = indexKey
 	}
 	// Use a scoped subject to avoid collisions with preview codes or other sharings
-	code, err := inst.CreateShareCode("interact:" + s.SID + ":" + key)
+	code, err := inst.CreateShareCode("interact:"+s.SID+":"+key, permission.ShareInteractPermissionID(s.SID))
 	if err != nil {
 		return "", err
 	}
@@ -456,7 +468,7 @@ func (s *Sharing) createInteractPermissions(inst *instance.Instance, m *Member) 
 		key = m.Instance
 	}
 	// Use a scoped subject to avoid collisions with preview codes or other sharings
-	code, err := inst.CreateShareCode("interact:" + s.SID + ":" + key)
+	code, err := inst.CreateShareCode("interact:"+s.SID+":"+key, permission.ShareInteractPermissionID(s.SID))
 	if err != nil {
 		return "", err
 	}

--- a/web/permissions/permissions.go
+++ b/web/permissions/permissions.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/metadata"
 	"github.com/cozy/cozy-stack/pkg/prefixer"
 	"github.com/cozy/cozy-stack/web/middlewares"
+	"github.com/gofrs/uuid/v5"
 	"github.com/justincampbell/bigduration"
 	"github.com/labstack/echo/v4"
 )
@@ -201,6 +202,11 @@ func HandleCreateShareByLink(c echo.Context, inst *instance.Instance, opts Creat
 	names := strings.Split(c.QueryParam("codes"), ",")
 	ttl := c.QueryParam("ttl")
 	tiny, _ := strconv.ParseBool(c.QueryParam("tiny"))
+	permissionID, err := uuid.NewV7()
+	if err != nil {
+		return err
+	}
+	subdoc.SetID(permissionID.String())
 
 	// Process TTL/expiration
 	var expiresAt interface{}
@@ -231,7 +237,7 @@ func HandleCreateShareByLink(c echo.Context, inst *instance.Instance, opts Creat
 		codes = make(map[string]string, len(names))
 		shortcodes = make(map[string]string, len(names))
 		for _, name := range names {
-			longcode, err := inst.CreateShareCode(name)
+			longcode, err := inst.CreateShareCode(name, subdoc.ID())
 			if err != nil {
 				return err
 			}

--- a/web/permissions/permissions_test.go
+++ b/web/permissions/permissions_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/crypto"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	"github.com/cozy/cozy-stack/web/errors"
 	"github.com/cozy/cozy-stack/web/middlewares"
@@ -283,15 +284,31 @@ func TestPermissions(t *testing.T) {
 	t.Run("CreateSubPermission", func(t *testing.T) {
 		e := testutils.CreateTestClient(t, ts.URL)
 
-		_, codes, err := createTestSubPermissions(e, token, "alice,bob")
+		id, codes, err := createTestSubPermissions(e, token, "alice,bob")
 		require.NoError(t, err)
 
 		aCode := codes.Value("alice").String().NotEmpty().Raw()
 		bCode := codes.Value("bob").String().NotEmpty().Raw()
+		otherID, otherCodes, err := createTestSubPermissions(e, token, "alice")
+		require.NoError(t, err)
+		otherCode := otherCodes.Value("alice").String().NotEmpty().Raw()
 
 		assert.NotEqual(t, aCode, token)
 		assert.NotEqual(t, bCode, token)
 		assert.NotEqual(t, aCode, bCode)
+		assert.NotEqual(t, id, otherID)
+		assert.NotEqual(t, aCode, otherCode)
+		for _, share := range []struct {
+			permissionID string
+			code         string
+		}{{id, aCode}, {id, bCode}, {otherID, otherCode}} {
+			var claims permission.Claims
+			err := crypto.ParseJWT(share.code, func(_ *jwt.Token) (interface{}, error) {
+				return testInstance.PickKey(consts.ShareAudience)
+			}, &claims)
+			require.NoError(t, err)
+			assert.Equal(t, share.permissionID, claims.ID)
+		}
 
 		obj := e.GET("/permissions/self").
 			WithHeader("Authorization", "Bearer "+aCode).
@@ -302,6 +319,10 @@ func TestPermissions(t *testing.T) {
 		perms := obj.Path("$.data.attributes.permissions").Object()
 		perms.Keys().Length().Equal(2)
 		perms.Path("$.whatever.type").String().Equal("io.cozy.files")
+
+		e.GET("/permissions/self").
+			WithHeader("Authorization", "Bearer "+otherCode).
+			Expect().Status(200)
 	})
 
 	t.Run("CreateSubSubFail", func(t *testing.T) {

--- a/web/sharings/sharings_test.go
+++ b/web/sharings/sharings_test.go
@@ -620,7 +620,7 @@ func TestSharings(t *testing.T) {
 		require.NoError(t, err)
 		perms, err := permission.GetForSharePreview(aliceInstance, sharingID)
 		require.NoError(t, err)
-		fooShareCode, err := aliceInstance.CreateShareCode(newMemberMail)
+		fooShareCode, err := aliceInstance.CreateShareCode(newMemberMail, perms.ID())
 		require.NoError(t, err)
 
 		// Adding its sharecode


### PR DESCRIPTION
## Summary

- Bug: share permission documents created with the same subject in the same second could produce identical tokens.
- Fix: use a generated UUID as both the JWT jti and the permission document ID while retaining byToken lookup.
- Next: use jti for direct permission lookup.