### PR TITLE
fix(testutils): avoid container port allocation races

### DIFF
--- a/tests/testutils/clamav_utils.go
+++ b/tests/testutils/clamav_utils.go
@@ -7,10 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 
-	c "github.com/docker/docker/api/types/container"
 	tc "github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -30,14 +28,6 @@ type ClamAVFixture struct {
 func StartClamAV(t *testing.T) *ClamAVFixture {
 	t.Helper()
 
-	clamdHostPort := getFreePort(t)
-
-	hostCfg := func(hc *c.HostConfig) {
-		hc.PortBindings = nat.PortMap{
-			"3310/tcp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: clamdHostPort}},
-		}
-	}
-
 	req := tc.ContainerRequest{
 		Image:         "clamav/clamav:stable",
 		ImagePlatform: "linux/amd64", // Force amd64 platform for ARM Macs
@@ -46,7 +36,6 @@ func StartClamAV(t *testing.T) *ClamAVFixture {
 			// Skip freshclam initial update for faster startup in tests
 			"CLAMAV_NO_FRESHCLAMD": "true",
 		},
-		HostConfigModifier: hostCfg,
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort("3310/tcp"),
 			wait.ForLog("socket found, clamd started").WithStartupTimeout(120*time.Second),
@@ -61,6 +50,9 @@ func StartClamAV(t *testing.T) *ClamAVFixture {
 
 	host, err := container.Host(context.Background())
 	require.NoError(t, err, "failed to get host for ClamAV")
+	clamdPort, err := container.MappedPort(context.Background(), "3310/tcp")
+	require.NoError(t, err, "failed to get port for ClamAV")
+	clamdHostPort := clamdPort.Port()
 
 	fixture := &ClamAVFixture{
 		Container: container,

--- a/tests/testutils/rabbitmq_utils.go
+++ b/tests/testutils/rabbitmq_utils.go
@@ -43,10 +43,7 @@ func StartRabbitMQ(t *testing.T, withVolume bool, enableTLS bool) *RabbitFixture
 	pass := "guest"
 
 	// Unique volume name if you want persistence across Stop/Start *within the test*.
-	amqpHostPort := getFreePort(t)
-	httpHostPort := getFreePort(t)
-	amqpsHostPort := ""
-
+	var amqpHostPort, httpHostPort, amqpsHostPort string
 	volName := "rmq_" + regexp.MustCompile(`[^a-z0-9_.-]+`).ReplaceAllString(strings.ToLower(t.Name()), "")
 	hostCfg := func(hc *c.HostConfig) {
 		hc.PortBindings = nat.PortMap{
@@ -54,7 +51,6 @@ func StartRabbitMQ(t *testing.T, withVolume bool, enableTLS bool) *RabbitFixture
 			"15672/tcp": []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: httpHostPort}},
 		}
 		if enableTLS {
-			amqpsHostPort = getFreePort(t)
 			hc.PortBindings["5671/tcp"] = []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: amqpsHostPort}}
 
 			hc.Binds = append(hc.Binds,
@@ -88,10 +84,28 @@ func StartRabbitMQ(t *testing.T, withVolume bool, enableTLS bool) *RabbitFixture
 		}(),
 	}
 
-	container, err := tc.GenericContainer(context.Background(), tc.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	var container tc.Container
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		amqpHostPort = getFreePort(t)
+		httpHostPort = getFreePort(t)
+		if enableTLS {
+			amqpsHostPort = getFreePort(t)
+		}
+		container, err = tc.GenericContainer(context.Background(), tc.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+		})
+		if err == nil {
+			break
+		}
+		if container != nil {
+			_ = container.Terminate(context.Background())
+		}
+		if !strings.Contains(err.Error(), "port is already allocated") {
+			break
+		}
+	}
 	require.NoError(t, err, "failed to start RabbitMQ")
 
 	host, err := container.Host(context.Background())


### PR DESCRIPTION
## Summary

- Retry RabbitMQ startup if Docker claims a selected host port before binding it.
- Preserve RabbitMQ host ports across container restarts for reconnection tests.
- Let Testcontainers allocate the ClamAV port and read its mapped value.