### PR TITLE
feat: Check destination on move-like files PATCH

### DIFF
--- a/docs/files.md
+++ b/docs/files.md
@@ -1426,7 +1426,10 @@ file/directory to update, and the second one uses the path.
 
 Some specific attributes of the patch can be used:
 
-- `dir_id` attribute can be updated to move a file or directory
+- `dir_id` attribute can be updated to move a file or directory. Moving
+  requires POST permission on the destination directory, and moving a file or
+  directory from or into a shared drive is rejected: such moves must use
+  `POST /sharings/drives/move` instead
 - `move_to_trash` boolean to specify that the file needs to be moved to the
   trash
 - `permanent_delete` boolean to specify that the files needs to be deleted
@@ -1470,11 +1473,14 @@ Content-Type: application/vnd.api+json
 - 200 OK, when the file or directory metadata has been successfully updated
 - 400 Bad Request, when a the directory is asked to move to one of its
   sub-directories
-- 404 Not Found, when the file/directory wasn't existing
+- 403 Forbidden, when the permission does not allow PATCH on the target, or
+  POST on the destination directory of a move
+- 404 Not Found, when the file/directory wasn't existing, or when the
+  destination parent doesn't exist
 - 412 Precondition Failed, when the `If-Match` header is set and doesn't match
   the last revision of the file/directory
-- 422 Unprocessable Entity, when the sent data is invalid (for example, the
-  parent doesn't exist)
+- 422 Unprocessable Entity, when the sent data is invalid, or when the move
+  crosses a shared drive boundary
 
 #### Response
 

--- a/model/sharing/effective_access.go
+++ b/model/sharing/effective_access.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/permission"
+	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/couchdb/mango"
@@ -84,6 +85,23 @@ func (r *AccessResolver) ResolveForMember(targetID string, member *Member) (*Eff
 	})
 }
 
+// HasDriveSharing reports whether at least one drive sharing applies to the
+// target, i.e. the target is a drive root or lives under one. The target doc
+// is passed by the caller (exactly one of dir/file must be non-nil) to avoid
+// re-fetching a doc the caller already has.
+func (r *AccessResolver) HasDriveSharing(dir *vfs.DirDoc, file *vfs.FileDoc) (bool, error) {
+	sharings, _, err := r.applicableSharingsForDoc(dir, file)
+	if err != nil {
+		return false, err
+	}
+	for _, s := range sharings {
+		if s.Drive && s.MemberFor(r.inst) != nil {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (r *AccessResolver) resolve(targetID string, memberOf func(*Sharing) *Member) (*EffectiveAccess, error) {
 	scopes, err := r.scopesMatching(targetID, memberOf)
 	if err != nil {
@@ -144,17 +162,23 @@ func (r *AccessResolver) scopesMatching(targetID string, memberOf func(*Sharing)
 // ancestor directory, without any membership filtering. It also returns the
 // root info of each sharing, keyed by sharing ID.
 func (r *AccessResolver) applicableSharings(targetID string) ([]*Sharing, map[string]rootInfo, error) {
-	fs := r.inst.VFS()
-
-	dir, file, err := fs.DirOrFileByID(targetID)
+	dir, file, err := r.inst.VFS().DirOrFileByID(targetID)
 	if err != nil {
 		return nil, nil, err
 	}
 	if dir == nil && file == nil {
 		return nil, nil, os.ErrNotExist
 	}
+	return r.applicableSharingsForDoc(dir, file)
+}
+
+// applicableSharingsForDoc is applicableSharings with the target doc already
+// loaded by the caller (exactly one of dir/file must be non-nil).
+func (r *AccessResolver) applicableSharingsForDoc(dir *vfs.DirDoc, file *vfs.FileDoc) ([]*Sharing, map[string]rootInfo, error) {
+	fs := r.inst.VFS()
 
 	var targetPath string
+	var err error
 	if dir != nil {
 		targetPath = dir.Fullpath
 	} else {

--- a/web/files/files.go
+++ b/web/files/files.go
@@ -722,6 +722,10 @@ func applyPatch(c echo.Context, fs vfs.VFS, patch *docPatch) (err error) {
 		return err
 	}
 
+	if err = checkMoveDestination(c, fs, patch, dir, file); err != nil {
+		return err
+	}
+
 	if patch.Delete {
 		if dir != nil {
 			inst := middlewares.GetInstance(c)
@@ -775,6 +779,9 @@ func applyPatches(c echo.Context, fs vfs.VFS, patches []*docPatch) (errors []*js
 			continue
 		}
 		if err = checkPerm(c, permission.PATCH, dir, file); err != nil {
+			return
+		}
+		if err = checkMoveDestination(c, fs, patch, dir, file); err != nil {
 			return
 		}
 		var errp error
@@ -2241,6 +2248,12 @@ func WrapVfsError(err error) error {
 }
 
 func wrapVfsErrorJSONAPI(err error) *jsonapi.Error {
+	if errj, ok := err.(*jsonapi.Error); ok {
+		return errj
+	}
+	if he, ok := err.(*echo.HTTPError); ok {
+		return jsonapi.Errorf(he.Code, "%v", he.Message)
+	}
 	if errj := wrapVfsError(err); errj != nil {
 		return errj
 	}
@@ -2417,6 +2430,58 @@ func checkPerm(c echo.Context, v permission.Verb, d *vfs.DirDoc, f *vfs.FileDoc)
 		return middlewares.AllowVFS(c, v, d)
 	}
 	return middlewares.AllowVFS(c, v, f)
+}
+
+// checkMoveDestination enforces the extra authorization required when a
+// PATCH behaves like a move (changes the parent directory): the destination
+// must exist, the caller needs POST on it, and moves touching a shared drive
+// are rejected here.
+//
+// ponytail: strict rejection — shared-drive moves must go through
+// POST /sharings/drives/move; lift when the shared-aware move task
+// implements delegation.
+func checkMoveDestination(c echo.Context, fs vfs.VFS, patch *docPatch, dir *vfs.DirDoc, file *vfs.FileDoc) error {
+	if patch.DirID == nil || patch.Trash || patch.Delete {
+		return nil
+	}
+	var currentDirID string
+	if dir != nil {
+		currentDirID = dir.DirID
+	} else {
+		currentDirID = file.DirID
+	}
+	if *patch.DirID == currentDirID {
+		return nil // dir_id set to its current value: not a move
+	}
+	newParent, _, err := fs.DirOrFileByID(*patch.DirID)
+	if err != nil {
+		return err
+	}
+	if newParent == nil {
+		return jsonapi.BadRequest(errors.New("destination is not a directory"))
+	}
+	if err := middlewares.AllowVFS(c, permission.POST, newParent); err != nil {
+		return err
+	}
+	resolver := sharing.NewAccessResolver(middlewares.GetInstance(c))
+	if err := checkSharedDrive(resolver, dir, file); err != nil {
+		return err
+	}
+	return checkSharedDrive(resolver, newParent, nil)
+}
+
+// checkSharedDrive rejects the move if the doc (dir or file) belongs to a
+// shared drive.
+func checkSharedDrive(r *sharing.AccessResolver, d *vfs.DirDoc, f *vfs.FileDoc) error {
+	shared, err := r.HasDriveSharing(d, f)
+	if err != nil {
+		return err
+	}
+	if shared {
+		return jsonapi.NewError(http.StatusUnprocessableEntity,
+			"moving to or from a shared drive must use POST /sharings/drives/move")
+	}
+	return nil
 }
 
 func parseMD5Hash(md5B64 string) ([]byte, error) {

--- a/web/files/permissions_test.go
+++ b/web/files/permissions_test.go
@@ -120,4 +120,60 @@ func TestPermissions(t *testing.T) {
 			WithHeader("Authorization", "Bearer "+badtok).
 			Expect().Status(403)
 	})
+
+	t.Run("MoveToForbiddenDestinationDenied", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		createDir := func(name string) string {
+			return e.POST("/files/").
+				WithQuery("Name", name).
+				WithQuery("Type", "directory").
+				WithHeader("Authorization", "Bearer "+token).
+				Expect().Status(201).
+				JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+				Object().Path("$.data.id").String().NotEmpty().Raw()
+		}
+		srcDirID := createDir("move-src")
+		dstDirID := createDir("move-dst")
+
+		fileID := e.POST("/files/"+srcDirID).
+			WithQuery("Name", "movable.txt").
+			WithQuery("Type", "file").
+			WithHeader("Content-Type", "text/plain").
+			WithHeader("Authorization", "Bearer "+token).
+			WithBytes([]byte("hello")).
+			Expect().Status(201).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object().Path("$.data.id").String().NotEmpty().Raw()
+
+		// The token can PATCH the file through its parent directory, but
+		// cannot POST into the destination directory.
+		srctok, _ := testInstance.MakeJWT(consts.AccessTokenAudience, client.ClientID, "io.cozy.files:ALL:"+srcDirID, "", time.Now())
+
+		e.PATCH("/files/"+fileID).
+			WithHeader("Content-Type", "application/json").
+			WithHeader("Authorization", "Bearer "+srctok).
+			WithBytes([]byte(`{"data":{"type":"io.cozy.files","id":"` + fileID + `","attributes":{"dir_id":"` + dstDirID + `"}}}`)).
+			Expect().Status(403)
+	})
+
+	t.Run("MoveToMissingDestinationNotFound", func(t *testing.T) {
+		e := testutils.CreateTestClient(t, ts.URL)
+
+		fileID := e.POST("/files/").
+			WithQuery("Name", "orphan-move.txt").
+			WithQuery("Type", "file").
+			WithHeader("Content-Type", "text/plain").
+			WithHeader("Authorization", "Bearer "+token).
+			WithBytes([]byte("hello")).
+			Expect().Status(201).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).
+			Object().Path("$.data.id").String().NotEmpty().Raw()
+
+		e.PATCH("/files/"+fileID).
+			WithHeader("Content-Type", "application/json").
+			WithHeader("Authorization", "Bearer "+token).
+			WithBytes([]byte(`{"data":{"type":"io.cozy.files","id":"` + fileID + `","attributes":{"dir_id":"does-not-exist"}}}`)).
+			Expect().Status(404)
+	})
 }

--- a/web/sharings/drives_test.go
+++ b/web/sharings/drives_test.go
@@ -6102,6 +6102,120 @@ func TestSharedDriveEffectiveAccessOnMoveDestination(t *testing.T) {
 	})
 }
 
+func TestFilesPatchRejectsSharedDriveMoves(t *testing.T) {
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+
+	env := setupSharedDrivesEnv(t)
+	eA, _, _ := env.createClients(t)
+
+	d1ID, d1RootID, _ := createSharedDrive(t, DriveCreationMethodFromFolder,
+		env.acme, env.acmeToken, env.tsA.URL, "Patch Move D1", "d1",
+		[]RecipientInfo{{Name: "Dave", Email: "dave@example.net", ReadOnly: false}})
+
+	insideFileID := createFile(t, eA, d1RootID, "inside.txt", env.acmeToken)
+	insideSubDirID := createDirectory(t, eA, d1RootID, "Sub", env.acmeToken)
+	outsideDirID := createRootDirectory(t, eA, "OutsideDrive", env.acmeToken)
+	outsideFileID := createFile(t, eA, outsideDirID, "outside.txt", env.acmeToken)
+	otherOutsideDirID := createRootDirectory(t, eA, "OtherOutside", env.acmeToken)
+
+	acceptSharedDrive(t, env.acme, env.dave, "Dave", env.tsA.URL, env.tsD.URL, d1ID)
+
+	movePayload := func(id, destID string) string {
+		return `{"data":{"type":"io.cozy.files","id":"` + id + `",` +
+			`"relationships":{"parent":{"data":{"type":"io.cozy.files","id":"` + destID + `"}}}}}`
+	}
+
+	t.Run("MoveFileInsideDriveDenied", func(t *testing.T) {
+		eA.PATCH("/files/"+insideFileID).
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(movePayload(insideFileID, insideSubDirID))).
+			Expect().Status(422)
+	})
+
+	t.Run("BatchMoveFileInsideDriveDenied", func(t *testing.T) {
+		// Batch PATCH aborts on the shared-drive rejection: the top-level
+		// error handler renders it as a single 422 error, not a 500.
+		batch := `{"data":[{"type":"io.cozy.files","id":"` + insideFileID + `",` +
+			`"attributes":{},` +
+			`"relationships":{"parent":{"data":{"type":"io.cozy.files","id":"` + insideSubDirID + `"}}}}]}`
+		eA.PATCH("/files/").
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(batch)).
+			Expect().Status(422).
+			JSON(httpexpect.ContentOpts{MediaType: "application/vnd.api+json"}).Object().
+			Value("errors").Array().Value(0).Object().
+			Value("status").IsEqual("422")
+	})
+
+	t.Run("MoveDriveFileToOutsideDenied", func(t *testing.T) {
+		eA.PATCH("/files/"+insideFileID).
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(movePayload(insideFileID, outsideDirID))).
+			Expect().Status(422)
+	})
+
+	t.Run("MoveOutsideFileIntoDriveDenied", func(t *testing.T) {
+		eA.PATCH("/files/"+outsideFileID).
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(movePayload(outsideFileID, d1RootID))).
+			Expect().Status(422)
+	})
+
+	t.Run("MoveOutsideDriveAllowed", func(t *testing.T) {
+		eA.PATCH("/files/"+outsideFileID).
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(movePayload(outsideFileID, otherOutsideDirID))).
+			Expect().Status(200)
+	})
+
+	t.Run("MoveIntoClassicSharingAllowed", func(t *testing.T) {
+		// Only shared drives require POST /sharings/drives/move: moving into
+		// a folder shared via a classic (non-drive) sharing stays allowed.
+		classicDirID := createRootDirectory(t, eA, "ClassicShare", env.acmeToken)
+		createClassicDirSharing(t, env.acme, classicDirID)
+		eA.PATCH("/files/"+outsideFileID).
+			WithHeader("Authorization", "Bearer "+env.acmeToken).
+			WithHeader("Content-Type", "application/json").
+			WithBytes([]byte(movePayload(outsideFileID, classicDirID))).
+			Expect().Status(200)
+	})
+}
+
+// createClassicDirSharing creates an active, owner-side classic (non-drive)
+// sharing rooted at the given directory, stamping referenced_by on it.
+func createClassicDirSharing(t *testing.T, inst *instance.Instance, rootID string) *sharing.Sharing {
+	t.Helper()
+	name, err := inst.SettingsPublicName()
+	require.NoError(t, err)
+	email, err := inst.SettingsEMail()
+	require.NoError(t, err)
+	s := &sharing.Sharing{
+		Active: true,
+		Owner:  true,
+		Members: []sharing.Member{{
+			Status:   sharing.MemberStatusOwner,
+			Name:     name,
+			Email:    email,
+			Instance: "https://" + inst.Domain,
+		}},
+		Rules: []sharing.Rule{{
+			Title:   "classic",
+			DocType: consts.Files,
+			Values:  []string{rootID},
+		}},
+	}
+	require.NoError(t, couchdb.CreateDoc(inst, s))
+	require.NoError(t, s.AddReferenceForSharing(inst, &s.Rules[0]))
+	return s
+}
+
 func TestSharedDriveEffectiveAccessOnTrashRoutes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")


### PR DESCRIPTION
  A PATCH on /files can move a file or folder by changing its parent,
  but only the target was authorized. Now checkMoveDestination requires
  the destination to exist and POST permission on it, and rejects with
  422 any move whose source or destination belongs to a shared drive:
  those must go through POST /sharings/drives/move until the
  shared-aware move task implements delegation.