### PR TITLE
feat: Add trial ending banner

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -1360,3 +1360,6 @@ msgstr "Your workspace is temporarily restricted"
 
 msgid "Banners Billing Support Label"
 msgstr "Contact support"
+
+msgid "Banners Trial Ending Text"
+msgstr "Your free trial will end on %s."

--- a/assets/locales/fr.po
+++ b/assets/locales/fr.po
@@ -1470,3 +1470,6 @@ msgstr "Mettre à jour le moyen de paiement"
 
 msgid "Banners Billing Support Label"
 msgstr "Contacter le support"
+
+msgid "Banners Trial Ending Text"
+msgstr "Votre période d'essai gratuite se terminera le %s."

--- a/assets/locales/ru.po
+++ b/assets/locales/ru.po
@@ -1418,3 +1418,6 @@ msgstr "Обновить способ оплаты"
 
 msgid "Banners Billing Support Label"
 msgstr "Связаться со службой поддержки"
+
+msgid "Banners Trial Ending Text"
+msgstr "Ваш бесплатный пробный период закончится %s."

--- a/assets/locales/vi.po
+++ b/assets/locales/vi.po
@@ -1390,3 +1390,6 @@ msgstr "Cập nhật phương thức thanh toán"
 
 msgid "Banners Billing Support Label"
 msgstr "Liên hệ bộ phận hỗ trợ"
+
+msgid "Banners Trial Ending Text"
+msgstr "Bản dùng thử miễn phí của bạn sẽ kết thúc vào ngày %s."

--- a/model/banner/banner_test.go
+++ b/model/banner/banner_test.go
@@ -14,7 +14,7 @@ import (
 // TestMain loads the real catalogs, so a message id that no longer exists
 // fails here rather than rendering its own name to a user.
 func TestMain(m *testing.M) {
-	for _, locale := range []string{"en", "fr"} {
+	for _, locale := range []string{"en", "fr", "ru", "vi"} {
 		po, err := os.ReadFile("../../assets/locales/" + locale + ".po")
 		if err != nil {
 			panic(err)
@@ -351,5 +351,93 @@ func TestEvaluateBilling(t *testing.T) {
 		require.Nil(t, b.CTA, "no manager URL is configured in this state")
 		ensureEscapable(b)
 		assert.True(t, b.Dismissible, "otherwise the user cannot reach the application at all")
+	})
+}
+
+func TestEvaluateTrial(t *testing.T) {
+	endsAt := now.Add(14 * 24 * time.Hour)
+	state := func(status string) TrialState {
+		return TrialState{Status: status, EndsAt: endsAt, Locale: "en"}
+	}
+
+	t.Run("a banner while the trial is running", func(t *testing.T) {
+		b := EvaluateTrial(state("trialing"), now)
+		require.NotNil(t, b)
+		assert.Equal(t, BannerIDTrialEnding, b.BannerID)
+		assert.Equal(t, CategoryTrial, b.Category)
+		assert.Equal(t, SeverityInfo, b.Severity)
+		assert.Equal(t, SurfaceBanner, b.Surface)
+		assert.True(t, b.Dismissible, "it stands for two weeks")
+		assert.Equal(t, 25, b.Priority, "a real problem always outranks it")
+		assert.Nil(t, b.SecondaryCTA, "nothing is blocked here")
+		assert.Equal(t, TriggerTrialChanged, b.Source.Trigger)
+		assert.Equal(t, now, b.Source.At)
+	})
+
+	t.Run("the window ends when the trial does, so the banner expires without an event", func(t *testing.T) {
+		b := EvaluateTrial(state("trialing"), now)
+		require.NotNil(t, b)
+		require.NotNil(t, b.StartsAt)
+		assert.Equal(t, now, *b.StartsAt)
+		require.NotNil(t, b.EndsAt)
+		assert.Equal(t, endsAt, *b.EndsAt)
+	})
+
+	t.Run("nothing once the trial is over, whatever ended it", func(t *testing.T) {
+		for _, status := range []string{"active", "canceled", "past_due"} {
+			assert.Nil(t, EvaluateTrial(state(status), now), status)
+		}
+	})
+
+	t.Run("nothing when the end date is unknown", func(t *testing.T) {
+		assert.Nil(t, EvaluateTrial(TrialState{Status: "trialing", Locale: "en"}, now),
+			"a window ending at the zero time would occupy the slot and show nothing")
+	})
+
+	t.Run("nothing when the trial has already ended", func(t *testing.T) {
+		stale := state("trialing")
+		stale.EndsAt = now.Add(-time.Hour)
+		assert.Nil(t, EvaluateTrial(stale, now),
+			"a trialing event redelivered after the trial is over must not recreate the banner")
+	})
+
+	t.Run("a call to action only when the manager URL is one", func(t *testing.T) {
+		without := EvaluateTrial(state("trialing"), now)
+		require.NotNil(t, without)
+		assert.Nil(t, without.CTA)
+
+		s := state("trialing")
+		s.ManagerURL = "https://manager.example.org/premium"
+		with := EvaluateTrial(s, now)
+		require.NotNil(t, with)
+		require.NotNil(t, with.CTA)
+		assert.Equal(t, "https://manager.example.org/premium", with.CTA.URL)
+
+		s.ManagerURL = "javascript:alert(1)"
+		assert.Nil(t, EvaluateTrial(s, now).CTA)
+	})
+
+	t.Run("the text carries the date, localized like every other banner", func(t *testing.T) {
+		french := state("trialing")
+		french.Locale = "fr"
+		b := EvaluateTrial(french, now)
+		require.NotNil(t, b)
+		assert.Equal(t, "fr", b.Lang)
+		assert.Equal(t, "Votre période d'essai gratuite se terminera le 5 août 2026.", b.Text)
+
+		english := EvaluateTrial(state("trialing"), now)
+		require.NotNil(t, english)
+		assert.Equal(t, "Your free trial will end on 5 August 2026.", english.Text)
+	})
+
+	t.Run("every locale that carries the wording carries the date with it", func(t *testing.T) {
+		for _, locale := range []string{"en", "fr", "ru", "vi"} {
+			s := state("trialing")
+			s.Locale = locale
+			b := EvaluateTrial(s, now)
+			require.NotNil(t, b, locale)
+			assert.Contains(t, b.Text, "2026", "%s dropped the placeholder", locale)
+			assert.NotContains(t, b.Text, "%!", locale)
+		}
 	})
 }

--- a/model/banner/billing.go
+++ b/model/banner/billing.go
@@ -4,9 +4,6 @@ import (
 	"time"
 
 	"github.com/cozy/cozy-stack/model/instance"
-	"github.com/cozy/cozy-stack/model/instance/lifecycle"
-	"github.com/cozy/cozy-stack/pkg/config/config"
-	"github.com/cozy/cozy-stack/pkg/prefixer"
 )
 
 // BannerIDBillingRestricted identifies the one payment state that has an
@@ -76,55 +73,14 @@ func EvaluateBilling(state BillingState, now time.Time) *Banner {
 }
 
 // RefreshBilling re-evaluates the billing banner of an instance from a payment
-// event. eventAt is the moment Stripe recorded the event, not the moment this
-// runs, so it both stamps the document and orders it against what is stored.
+// event.
 func RefreshBilling(domain, status string, eventAt time.Time) error {
-	inst, err := lifecycle.GetInstance(domain)
-	if err != nil {
-		return err
-	}
-	if !inst.HasBannersEnabled() {
-		return nil
-	}
-
-	mu := config.Lock().ReadWrite(inst, "banners")
-	if err := mu.Lock(); err != nil {
-		return err
-	}
-	defer mu.Unlock()
-
-	stale, err := supersededBy(inst, CategoryBilling, eventAt)
-	if err != nil || stale {
-		return err
-	}
-
-	state := BillingState{
-		Status:      status,
-		Locale:      inst.Locale,
-		ContextName: inst.ContextName,
-	}
-	if premium, err := inst.ManagerURL(instance.ManagerPremiumURL); err == nil {
-		state.ManagerURL = premium
-	}
-
-	return Materialize(inst, CategoryBilling, EvaluateBilling(state, eventAt), time.Now())
-}
-
-// supersededBy reports whether the stored banner was produced by an event at
-// least as recent as this one, in which case this one is a redelivery or
-// arrived out of order. Bus delivery is at-least-once and unordered, so
-// without this a redelivered failure could overwrite a recovery.
-//
-// ponytail: Source.At is the event that last changed the document, not the
-// last one seen, since an unchanged re-evaluation writes nothing. So a failure
-// redelivered after a recovery deleted the document recreates it, and a stale
-// recovery between two identical failures clears it. Both need a single queue
-// reordered or a replay past the Cloudery's own dedupe; record the last
-// applied event time per instance if that ever happens.
-func supersededBy(db prefixer.Prefixer, category string, eventAt time.Time) (bool, error) {
-	stored, err := Stored(db, category)
-	if err != nil || stored == nil {
-		return false, err
-	}
-	return !stored.Source.At.Before(eventAt), nil
+	return refresh(domain, CategoryBilling, eventAt, func(inst *instance.Instance, managerURL string) *Banner {
+		return EvaluateBilling(BillingState{
+			Status:      status,
+			Locale:      inst.Locale,
+			ContextName: inst.ContextName,
+			ManagerURL:  managerURL,
+		}, eventAt)
+	})
 }

--- a/model/banner/materialize.go
+++ b/model/banner/materialize.go
@@ -3,6 +3,9 @@ package banner
 import (
 	"time"
 
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/logger"
@@ -171,4 +174,60 @@ func Stored(db prefixer.Prefixer, category string) (*Banner, error) {
 		return nil, err
 	}
 	return &doc, nil
+}
+
+// refresh re-evaluates one category of an instance from a bus event, and is
+// what both the payment and the trial entry points are. eventAt is the moment
+// Stripe recorded the event, not the moment this runs, so it both stamps the
+// document and orders it against what is stored. evaluate receives the manager
+// premium page, empty when the stack does not know it.
+func refresh(domain, category string, eventAt time.Time, evaluate func(inst *instance.Instance, managerURL string) *Banner) error {
+	inst, err := lifecycle.GetInstance(domain)
+	if err != nil {
+		return err
+	}
+	if !inst.HasBannersEnabled() {
+		return nil
+	}
+
+	// One lock name for every category, deliberately: at expiry the Cloudery
+	// sends trial.changed and payment.failed from one Stripe event, and this
+	// makes the two run one after the other rather than racing.
+	mu := config.Lock().ReadWrite(inst, "banners")
+	if err := mu.Lock(); err != nil {
+		return err
+	}
+	defer mu.Unlock()
+
+	stale, err := supersededBy(inst, category, eventAt)
+	if err != nil || stale {
+		return err
+	}
+
+	var managerURL string
+	if premium, err := inst.ManagerURL(instance.ManagerPremiumURL); err == nil {
+		managerURL = premium
+	}
+
+	return Materialize(inst, category, evaluate(inst, managerURL), time.Now())
+}
+
+// supersededBy reports whether the stored banner was produced by an event at
+// least as recent as this one, in which case this one is a redelivery or
+// arrived out of order. Bus delivery is at-least-once and unordered, so
+// without this a redelivered failure could overwrite a recovery.
+//
+// ponytail: Source.At is the event that last changed the document, not the
+// last one seen, since an unchanged re-evaluation writes nothing. So an event
+// redelivered after a later one deleted the document recreates it. Both rules
+// bound the damage themselves, the trial through its validity window and the
+// payment one through the next event, and both need a single queue reordered
+// or a replay past the Cloudery's own dedupe. Record the last applied event
+// time per instance if that ever happens.
+func supersededBy(db prefixer.Prefixer, category string, eventAt time.Time) (bool, error) {
+	stored, err := Stored(db, category)
+	if err != nil || stored == nil {
+		return false, err
+	}
+	return !stored.Source.At.Before(eventAt), nil
 }

--- a/model/banner/quota.go
+++ b/model/banner/quota.go
@@ -103,9 +103,10 @@ func ctaTarget(raw string) string {
 
 // translate falls back to English inside i18n for an untranslated locale,
 // which is why Lang says the language that was asked for rather than the one
-// that came out.
-func translate(locale, context, msgid string) string {
-	return i18n.Translate(msgid, lang(locale), context)
+// that came out. vars are interpolated into the translated wording, and a
+// msgid with no verb in it takes none.
+func translate(locale, context, msgid string, vars ...interface{}) string {
+	return i18n.Translate(msgid, lang(locale), context, vars...)
 }
 
 func lang(locale string) string {

--- a/model/banner/trial.go
+++ b/model/banner/trial.go
@@ -1,0 +1,95 @@
+package banner
+
+import (
+	"time"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/pkg/i18n"
+)
+
+// BannerIDTrialEnding identifies the one occurrence a trial has. The id names
+// the condition rather than the date, so re-materializing an unchanged trial
+// keeps a dismissal.
+const BannerIDTrialEnding = "trial.ending"
+
+// TriggerTrialChanged is recorded on documents produced by a trial event.
+const TriggerTrialChanged = "trial.changed"
+
+// The wording, as a message id of the stack locales. It takes the end date.
+const textTrialEnding = "Banners Trial Ending Text"
+
+// trialDateLayout is the end date as the wording reads it. Day before month,
+// which is the order en, fr, ru and vi all write.
+//
+// ponytail: monday v1.0.2 has no vi locale, so Vietnamese wording gets an
+// English month name. Nothing to map it to short of a date formatter of our
+// own, and the order is right, so it stays as it is.
+const trialDateLayout = "2 January 2006"
+
+// TrialState is what the trial rule needs to decide, kept separate from the
+// instance so the rule stays testable without one.
+type TrialState struct {
+	// Status is the subscription status as Stripe reports it, verbatim.
+	Status string
+	// EndsAt is when the trial ends, known from the day it starts.
+	EndsAt time.Time
+	Locale string
+	// ContextName can override a translation.
+	ContextName string
+	// ManagerURL is where the call to action points, empty when unknown.
+	ManagerURL string
+}
+
+// EvaluateTrial returns the banner that applies to a trial, or nil when none
+// does. Every status but trialing is a trial that is over, whether it
+// converted, ran out or failed its first charge, and nil is what deletes the
+// document.
+func EvaluateTrial(state TrialState, now time.Time) *Banner {
+	if state.Status != "trialing" {
+		return nil
+	}
+	// A window ending at the zero time is dropped by every client while still
+	// occupying the slot, and one that has already closed says nothing true.
+	// The second case is what a redelivered trialing event looks like after the
+	// trial is over, which supersededBy cannot catch once the document it
+	// ordered against has been deleted.
+	if state.EndsAt.IsZero() || !state.EndsAt.After(now) {
+		return nil
+	}
+
+	startsAt := now
+	endsAt := state.EndsAt
+	banner := &Banner{
+		BannerID:    BannerIDTrialEnding,
+		Category:    CategoryTrial,
+		Severity:    SeverityInfo,
+		Surface:     SurfaceBanner,
+		Text:        translate(state.Locale, state.ContextName, textTrialEnding, i18n.LocalizeTime(state.EndsAt, lang(state.Locale), trialDateLayout)),
+		Lang:        lang(state.Locale),
+		Dismissible: true,
+		Priority:    25,
+		StartsAt:    &startsAt,
+		// Load bearing: the stack has no scheduled evaluation, so the client
+		// evaluating this window against its own clock is what makes the
+		// banner go away on the day the trial ends, message or no message.
+		EndsAt: &endsAt,
+		Source: Source{Trigger: TriggerTrialChanged, At: now},
+	}
+	if target := ctaTarget(state.ManagerURL); target != "" {
+		banner.CTA = &CTA{Label: translate(state.Locale, state.ContextName, textBillingCTALabel), URL: target}
+	}
+	return banner
+}
+
+// RefreshTrial re-evaluates the trial banner of an instance from a trial event.
+func RefreshTrial(domain, status string, endsAt, eventAt time.Time) error {
+	return refresh(domain, CategoryTrial, eventAt, func(inst *instance.Instance, managerURL string) *Banner {
+		return EvaluateTrial(TrialState{
+			Status:      status,
+			EndsAt:      endsAt,
+			Locale:      inst.Locale,
+			ContextName: inst.ContextName,
+			ManagerURL:  managerURL,
+		}, eventAt)
+	})
+}

--- a/pkg/rabbitmq/contracts.go
+++ b/pkg/rabbitmq/contracts.go
@@ -1,5 +1,7 @@
 package rabbitmq
 
+import "time"
+
 const (
 	ExchangeAuth      = "auth"
 	ExchangeBilling   = "billing"
@@ -33,6 +35,7 @@ const (
 	RoutingKeyNextcloudMigrationCanceled  = "nextcloud.migration.canceled"
 	RoutingKeyPaymentFailed               = "payment.failed"
 	RoutingKeyPaymentRecovered            = "payment.recovered"
+	RoutingKeyTrialChanged                = "trial.changed"
 )
 
 // BillingLifecycleMessage is published by the Cloudery when a payment event
@@ -58,6 +61,12 @@ type BillingLifecycleMessage struct {
 	// Delivery is at-least-once and unordered, so this, not the arrival time,
 	// decides which event wins.
 	Timestamp int64 `json:"timestamp"`
+	// TrialEndsAt is when the free trial ends, known from the day it starts,
+	// so the banner can state an absolute date and no deadline trigger is
+	// needed. It rides on every lifecycle message rather than on a trial one
+	// because the Cloudery declares it on the shared base class the payment
+	// and trial messages both extend, so it is zero on a payment message.
+	TrialEndsAt time.Time `json:"trialEndsAt,omitempty"`
 }
 
 // UserDeletionRequestedMessage is published when a user asks Twake to delete the account linked to the current cozy instance.

--- a/pkg/rabbitmq/handlers.go
+++ b/pkg/rabbitmq/handlers.go
@@ -892,7 +892,16 @@ func (h *BillingLifecycleHandler) Handle(ctx context.Context, d amqp.Delivery) e
 
 	eventAt := time.Unix(msg.Timestamp, 0).UTC()
 	for _, domain := range domains {
-		if err := banner.RefreshBilling(domain, status, eventAt); err != nil {
+		var err error
+		// A trial carries its own statuses, and the rewrite above is about
+		// payments: the routing keys are distinct, so it cannot have reached
+		// one and the status arrives here as the Cloudery sent it.
+		if d.RoutingKey == RoutingKeyTrialChanged {
+			err = banner.RefreshTrial(domain, status, msg.TrialEndsAt, eventAt)
+		} else {
+			err = banner.RefreshBilling(domain, status, eventAt)
+		}
+		if err != nil {
 			return fmt.Errorf("billing.lifecycle: materialize for %s: %w", domain, err)
 		}
 		log.Infof("billing.lifecycle: %s applied to %s (status %s, attempt %d, event %s, at %s)",

--- a/pkg/rabbitmq/handlers_test.go
+++ b/pkg/rabbitmq/handlers_test.go
@@ -7,11 +7,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cozy/cozy-stack/model/banner"
+	"github.com/cozy/cozy-stack/model/instance"
 	"github.com/cozy/cozy-stack/model/instance/lifecycle"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/rabbitmq"
 	"github.com/cozy/cozy-stack/tests/testutils"
 	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,4 +97,107 @@ func TestUserCreatedHandlerStoresMatrixID(t *testing.T) {
 		require.NoError(t, handle(t, domain, ""))
 		require.Empty(t, storedMatrixID(t, domain))
 	})
+}
+
+// TestBillingLifecycleHandlerRoutesTrialEvents checks that a trial.changed
+// message reaches the trial rule rather than the payment one, and that the two
+// categories keep their own document.
+func TestBillingLifecycleHandlerRoutesTrialEvents(t *testing.T) {
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+
+	contextName := "trial-banner-test"
+	conf := config.GetConfig()
+	conf.Contexts = map[string]interface{}{
+		contextName: map[string]interface{}{"enable_banners": true},
+	}
+
+	eventAt := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	endsAt := eventAt.Add(14 * 24 * time.Hour)
+
+	newInstance := func(t *testing.T) *instance.Instance {
+		t.Helper()
+		domain := fmt.Sprintf("trial-banner-%d.example", time.Now().UnixNano())
+		inst, err := lifecycle.Create(&lifecycle.Options{
+			Domain: domain, Email: "alice@example.org", ContextName: contextName,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = lifecycle.Destroy(domain) })
+		return inst
+	}
+
+	handle := func(t *testing.T, routingKey string, msg rabbitmq.BillingLifecycleMessage) error {
+		t.Helper()
+		if msg.Timestamp == 0 {
+			msg.Timestamp = eventAt.Unix()
+		}
+		body, err := json.Marshal(msg)
+		require.NoError(t, err)
+		return rabbitmq.NewBillingLifecycleHandler().
+			Handle(context.Background(), amqp.Delivery{RoutingKey: routingKey, Body: body})
+	}
+
+	t.Run("a running trial materializes the trial banner", func(t *testing.T) {
+		inst := newInstance(t)
+
+		require.NoError(t, handle(t, rabbitmq.RoutingKeyTrialChanged, rabbitmq.BillingLifecycleMessage{
+			WorkplaceFqdn: inst.Domain, Status: "trialing", TrialEndsAt: endsAt,
+		}))
+
+		stored, err := banner.Stored(inst, banner.CategoryTrial)
+		require.NoError(t, err)
+		require.NotNil(t, stored, "the trial rule never ran, or trialing was rewritten to active")
+		assert.Equal(t, banner.BannerIDTrialEnding, stored.BannerID)
+		require.NotNil(t, stored.EndsAt)
+		assert.True(t, endsAt.Equal(*stored.EndsAt), "the deadline the client expires the banner on")
+
+		billing, err := banner.Stored(inst, banner.CategoryBilling)
+		require.NoError(t, err)
+		assert.Nil(t, billing, "a trial event must not write a payment banner")
+	})
+
+	t.Run("a converted trial removes the banner", func(t *testing.T) {
+		inst := newInstance(t)
+
+		require.NoError(t, handle(t, rabbitmq.RoutingKeyTrialChanged, rabbitmq.BillingLifecycleMessage{
+			WorkplaceFqdn: inst.Domain, Status: "trialing", TrialEndsAt: endsAt,
+		}))
+		require.NoError(t, handle(t, rabbitmq.RoutingKeyTrialChanged, rabbitmq.BillingLifecycleMessage{
+			WorkplaceFqdn: inst.Domain, Status: "active", TrialEndsAt: endsAt, Timestamp: eventAt.Add(time.Hour).Unix(),
+		}))
+
+		stored, err := banner.Stored(inst, banner.CategoryTrial)
+		require.NoError(t, err)
+		assert.Nil(t, stored)
+	})
+
+	t.Run("the two categories coexist", func(t *testing.T) {
+		inst := newInstance(t)
+
+		require.NoError(t, handle(t, rabbitmq.RoutingKeyTrialChanged, rabbitmq.BillingLifecycleMessage{
+			WorkplaceFqdn: inst.Domain, Status: "trialing", TrialEndsAt: endsAt,
+		}))
+		require.NoError(t, handle(t, rabbitmq.RoutingKeyPaymentFailed, rabbitmq.BillingLifecycleMessage{
+			WorkplaceFqdn: inst.Domain, Status: "unpaid",
+		}))
+
+		trial, err := banner.Stored(inst, banner.CategoryTrial)
+		require.NoError(t, err)
+		assert.NotNil(t, trial, "the payment banner evicted the trial one")
+
+		billing, err := banner.Stored(inst, banner.CategoryBilling)
+		require.NoError(t, err)
+		assert.NotNil(t, billing, "the trial banner evicted the payment one")
+	})
+}
+
+// TestBillingLifecycleMessageParsesTheTrialDeadline pins the wire shape: the
+// Cloudery renders the date with a numeric offset rather than Z. It has to
+// land as a usable time, or the whole message dead-letters and no banner ever
+// appears.
+func TestBillingLifecycleMessageParsesTheTrialDeadline(t *testing.T) {
+	var msg rabbitmq.BillingLifecycleMessage
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"workplaceFqdn":"a.example","status":"trialing","timestamp":1784721600,"trialEndsAt":"2026-08-05T12:00:00+00:00"}`), &msg))
+	assert.True(t, time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC).Equal(msg.TrialEndsAt))
 }

--- a/pkg/rabbitmq/rabbitmq.go
+++ b/pkg/rabbitmq/rabbitmq.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 
 	"crypto/tls"
@@ -277,6 +278,14 @@ func BuildExchangeSpecs(exchangesCfg []config.RabbitExchange) []ExchangeSpec {
 				handler = NewAppInstallHandler()
 			case QueueBillingLifecycle:
 				handler = NewBillingLifecycleHandler()
+				// Bindings come from the deployment config, not from the code,
+				// so a routing key missing there is silence: the Cloudery
+				// publishes, the exchange drops it, and no banner ever appears.
+				for _, key := range []string{RoutingKeyPaymentFailed, RoutingKeyPaymentRecovered, RoutingKeyTrialChanged} {
+					if !slices.Contains(configQueue.Bindings, key) {
+						log.Warnf("Queue %s is not bound to %s: those events will never be consumed", configQueue.Name, key)
+					}
+				}
 			}
 
 			if handler == nil {


### PR DESCRIPTION
Materializes a dismissible banner from billing trial events: "your trial ends on X", with a link to the manager.

The banner carries its own end date so clients expire it on their own, since the stack has no scheduled re-evaluation. Any status other than `trialing`, or an end date already past, deletes it. Post-trial states (conversion, dunning, grace) stay with the existing billing banners.