### PR TITLE
fix(common settings): take the matrix homeserver from the email domain

### DIFF
--- a/model/settings/common/common.go
+++ b/model/settings/common/common.go
@@ -304,25 +304,19 @@ func buildRequest(inst *instance.Instance, settings *couchdb.JSONDoc) UserSettin
 		request.Payload.FirstName = parts[0]
 		request.Payload.LastName = parts[len(parts)-1]
 	}
-	if email, ok := settings.M["email"].(string); ok {
-		request.Payload.Email = email
-	}
+	email, _ := settings.M["email"].(string)
+	request.Payload.Email = email
 	if phone, ok := settings.M["phone"].(string); ok {
 		request.Payload.Phone = phone
 	}
 	if matrixID, _ := settings.M["matrix_id"].(string); IsMatrixID(matrixID) {
 		request.Payload.MatrixID = matrixID
-	} else if len(parts) > 1 {
-		// The Matrix localpart comes from the email local part, which preserves
-		// dots and can differ from the domain slug. Fall back to the slug when
-		// no email is available. The homeserver part stays domain-derived.
-		localpart := nickname
-		email, _ := settings.M["email"].(string)
-		if local, _, found := strings.Cut(email, "@"); found && local != "" {
-			localpart = strings.ToLower(local)
+	} else if local, domain, found := strings.Cut(email, "@"); found {
+		// The homeserver is the mail domain: the instance domain is an
+		// unrelated value and must not be used here.
+		if id := strings.ToLower("@" + local + ":" + domain); IsMatrixID(id) {
+			request.Payload.MatrixID = id
 		}
-		id := fmt.Sprintf("@%s:%s", localpart, strings.Join(parts[1:], "."))
-		request.Payload.MatrixID = id
 	}
 
 	return request

--- a/model/settings/common/common_test.go
+++ b/model/settings/common/common_test.go
@@ -30,18 +30,25 @@ func TestBuildRequest_MatrixID(t *testing.T) {
 		require.Equal(t, "@al.ice:stg.lin-saas.com", req.Payload.MatrixID)
 	})
 
-	t.Run("falls back to the domain slug when no email is present", func(t *testing.T) {
-		settings := &couchdb.JSONDoc{M: map[string]interface{}{}}
-		req := buildRequest(inst, settings)
-		require.Equal(t, "@alicewonderland:stg.lin-saas.com", req.Payload.MatrixID)
+	t.Run("the homeserver is the mail domain, not the instance domain", func(t *testing.T) {
+		settings := &couchdb.JSONDoc{M: map[string]interface{}{
+			"email": "al.ice@linagora.com",
+		}}
+		req := buildRequest(&instance.Instance{Domain: "alice.twake.linagora.com"}, settings)
+		require.Equal(t, "@al.ice:linagora.com", req.Payload.MatrixID)
 	})
 
-	t.Run("single-label domain yields no matrix id", func(t *testing.T) {
-		local := &instance.Instance{Domain: "localhost"}
+	t.Run("no email yields no matrix id", func(t *testing.T) {
+		settings := &couchdb.JSONDoc{M: map[string]interface{}{}}
+		req := buildRequest(inst, settings)
+		require.Empty(t, req.Payload.MatrixID)
+	})
+
+	t.Run("an email without a domain yields no matrix id", func(t *testing.T) {
 		settings := &couchdb.JSONDoc{M: map[string]interface{}{
-			"email": "al.ice@example.org",
+			"email": "alicewonderland",
 		}}
-		req := buildRequest(local, settings)
+		req := buildRequest(inst, settings)
 		require.Empty(t, req.Payload.MatrixID)
 	})
 


### PR DESCRIPTION
## Problem

The Matrix ID that cozy-stack sends to the common settings service takes its homeserver part from the Cozy instance domain minus its first label. The instance host and the Matrix server_name are unrelated values that only coincide in some environments. On production, instances sit under twake.linagora.com while the server_name is linagora.com, so every derived ID is wrong and the profile update fails with `M_UNKNOWN "Can only look up local users"`.

## Solution

A stored matrix_id stays the source of truth. Otherwise the whole ID now comes from the email, homeserver included, so `alice@linagora.com` gives `@alice:linagora.com`. The instance domain is no longer read. An address with no domain part yields no matrix_id instead of a guess.

Closes #4906
