### PR TITLE
feat(rag): index the assistants' knowledge base folders on openRAG

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -576,6 +576,115 @@ Content-Type: application/json
 }
 ```
 
+## RAG indexing
+
+The RAG indexing of an instance follows the knowledge base folders of its
+assistants (see [ai.md](ai.md)): there is one checkpoint for the instance,
+and no per-folder trigger any more. These routes are operator tools.
+
+Only `reset` runs under the lock the `rag-index` jobs take (`purge` takes it
+just to drop the checkpoint, after having emptied openRAG). Run `prune` and
+`purge` when no `rag-index` job is running, or they may fight with it.
+
+### POST /instances/:domain/rag/reset
+
+Deletes the `rag-index` checkpoint of the instance and launches a `rag-index`
+job, so the whole changes feed is scanned again by the RAG indexer.
+
+#### Request
+
+```http
+POST /instances/alice.cozy.localhost/rag/reset HTTP/1.1
+```
+
+#### Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
+### POST /instances/:domain/rag/reconcile
+
+Pushes a reconcile job per knowledge base folder: the job walks the subtree
+of the folder and indexes every file it holds. With the `dir_id` query
+parameter, only that folder is reconciled. It is how an initial indexing that
+did not finish is restarted. `dir_id` is the folder id, the one the
+assistant's `knowledgeBase` carries (`io.cozy.files.root-dir` for the whole
+Drive), not the id of its openRAG workspace.
+
+#### Request
+
+```http
+POST /instances/alice.cozy.localhost/rag/reconcile?dir_id=6c36a9ee HTTP/1.1
+```
+
+#### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "jobs": 1
+}
+```
+
+A `404 Not Found` is returned when the given folder is in no assistant's
+knowledge base.
+
+### POST /instances/:domain/rag/prune
+
+Deletes from openRAG what no knowledge base folder claims any more: the files
+gone or trashed in the Cozy, the files outside every knowledge base folder,
+and the workspaces of the folders no assistant uses. The index status of a
+deleted file is dropped too. A workspace is named after its folder id, except
+for the well-known folders: openRAG refuses an id with dots, so the root
+folder (`io.cozy.files.root-dir`) is indexed in the workspace
+`io-cozy-files-root-dir`, and likewise for the trash, "Shared with me", "No
+longer shared" and "Shared drives".
+
+#### Request
+
+```http
+POST /instances/alice.cozy.localhost/rag/prune HTTP/1.1
+```
+
+#### Response
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+```json
+{
+  "files_scanned": 12,
+  "files_deleted": 3,
+  "workspaces_deleted": 1
+}
+```
+
+### POST /instances/:domain/rag/purge
+
+Deletes everything openRAG holds for the instance: its workspaces, its files
+and its partition. The index statuses and the `rag-index` checkpoint are
+dropped too, so the next run indexes the whole instance again (use the reset
+route above to launch it right away).
+
+#### Request
+
+```http
+POST /instances/alice.cozy.localhost/rag/purge HTTP/1.1
+```
+
+#### Response
+
+```http
+HTTP/1.1 204 No Content
+```
+
 ## Contexts
 
 ### GET /instances/contexts

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -16,24 +16,55 @@ First of all, the RAG server must be installed with its dependencies. It is
 not mandatory to install them on the same servers as the cozy-stack. And the
 URL of RAG must be filled in cozy-stack configuration file (in `rag`).
 
-For the moment, the feature is experimental, and a trigger must be created
-manually on the Cozy:
+The indexing follows the assistants: every `io.cozy.ai.chat.assistants`
+document whose `knowledgeBase` has an `io.cozy.files` entry defines a folder
+to index. The files of that folder (recursively) are sent to the openRAG
+server and attached to the workspace named after the folder id; the
+assistant's retrieval is scoped to that workspace.
 
-```sh
-$ COZY=cozy.localhost:8080
-$ TOKEN=$(cozy-stack instances token-cli $COZY io.cozy.triggers)
-$ curl "http://${COZY}/jobs/triggers" -H "Authorization: Bearer $TOKEN" -d '{ "data": { "attributes": { "type": "@event", "arguments": "io.cozy.files", "debounce": "1m", "worker": "rag-index", "message": {"doctype": "io.cozy.files"} } } }'
+openRAG indexes an upload asynchronously: while the task runs, it still
+answers 404 on the file but refuses a second POST with a 409. The worker then
+sends the file again with a PUT, which re-indexes the content, instead of
+failing on the conflict.
+
+openRAG also deduplicates by content: a partition holds one document per
+distinct content, and an upload whose content is already indexed under
+another file id is refused with a 409 `DOCUMENT_CONTENT_EXISTS`. The worker
+logs that file once (with the id of the document already holding the content)
+and skips it for good: it is not indexed, and not attached to any workspace,
+so a search hit points at the other copy. A reconcile of its folder does not
+change that — the second copy is refused again, and only counted in the
+summary of the walk.
+
+The `rag-index` worker does all of this in one job per instance, reading the
+changes feed of `io.cozy.files` from a checkpoint. It is woken up by two
+`@event` triggers, created by the app in charge of the assistants (the worker
+is not reserved, an app token with the `io.cozy.triggers` permission is
+enough):
+
+```json
+{ "data": { "attributes": {
+  "type": "@event", "arguments": "io.cozy.files", "debounce": "30s",
+  "worker": "rag-index", "message": { "doctype": "io.cozy.files" } } } }
 ```
 
-It can also be a good idea to start a first indexation with:
-
-```sh
-$ cozy-stack triggers launch --domain $COZY $TRIGGER_ID
+```json
+{ "data": { "attributes": {
+  "type": "@event", "arguments": "io.cozy.ai.chat.assistants",
+  "worker": "rag-index", "message": { "doctype": "io.cozy.files" } } } }
 ```
 
-In practice, when files are uploaded/modified/deleted, the trigger will create
-a job for the index worker (with debounce). The index worker will look at the
-changed feed, and will call the RAG for each entry in the changes feed.
+The second trigger only wakes the worker when an assistant is created,
+modified or deleted: the worker then creates the workspace of a new folder
+and pushes a job that walks its subtree (in that order: nothing is indexed
+into a workspace that does not exist, and a workspace whose job could not be
+pushed is deleted again, so the next run retries both), or removes the
+workspace of a folder no assistant uses any more (its files are deleted from
+openRAG when no other folder contains them).
+
+A chat on an assistant whose folder has no workspace yet (the job did not run
+since the assistant was created) fails with an error event saying the
+knowledge base is not indexed; it works once the job ran.
 
 By default, only text-based files are indexed. Images, videos, and audio files
 can be indexed by enabling the following feature flags:
@@ -41,6 +72,45 @@ can be indexed by enabling the following feature flags:
 - `rag.index.image.enabled`
 - `rag.index.video.enabled`
 - `rag.index.audio.enabled`
+
+### Operator tools
+
+The admin API exposes them (see [admin.md](admin.md) for the details):
+
+- `POST /instances/:domain/rag/reset` deletes the checkpoint and launches the
+  indexing: the whole changes feed is scanned again.
+- `POST /instances/:domain/rag/reconcile?dir_id=<id>` re-indexes the subtree
+  of one knowledge base folder (without `dir_id`, of all of them).
+- `POST /instances/:domain/rag/prune` deletes from openRAG the files no
+  knowledge base folder claims and the workspaces of folders no assistant uses.
+- `POST /instances/:domain/rag/purge` deletes everything openRAG holds for the
+  instance (files, workspaces, partition) and the checkpoint.
+
+A reconcile job skips the files openRAG refuses for good (an unsupported
+format, say); a file whose content is missing from the storage is skipped as
+well, since it will not come back: each one is logged and the walk goes on,
+so only transient errors (network, 5xx) fail the job and have the worker walk
+the folder again.
+A skipped file stays unindexed until it changes, or until an operator re-walks
+its folder with `POST /instances/:domain/rag/reconcile?dir_id=<id>`.
+
+Recovery: an initial indexing that did not finish (the job of a very large
+folder, a whole-Drive assistant typically, hit the worker timeout) is
+restarted with `POST /instances/:domain/rag/reconcile?dir_id=<id>`; nothing
+else replays it, since the files of the folder did not change. Removing a
+whole-Drive workspace is also much cheaper with the prune route, which
+makes one pass over openRAG's file list, than through the automatic detach of
+the workspace diff, which walks the subtree file by file. Note that prune and
+purge do not take the lock the indexing jobs use: run them when no rag-index
+job is running.
+
+A trigger can still be created by hand with a CLI token:
+
+```sh
+$ COZY=cozy.localhost:8080
+$ TOKEN=$(cozy-stack instances token-cli $COZY io.cozy.triggers)
+$ curl "http://${COZY}/jobs/triggers" -H "Authorization: Bearer $TOKEN" -d '{ "data": { "attributes": { "type": "@event", "arguments": "io.cozy.files", "debounce": "30s", "worker": "rag-index", "message": {"doctype": "io.cozy.files"} } } }'
+```
 
 ### POST /ai/index/status
 
@@ -66,6 +136,7 @@ Content-Type: application/json
   "metadata": {
     "doc_rev": "3-6a1b0b8a51a4e0e0a3b7f0f1d2c3b4a5",
     "datetime": "2026-08-20T08:12:00.000Z",
+    "created_at": "2026-08-20T08:12:03.512Z",
     "doctype": "io.cozy.files"
   }
 }
@@ -226,6 +297,10 @@ Content-Type: application/json
 - `websearch` enables web search for the query (defaults to `false`).
 - `assistantID` (optional) associates the conversation with an `io.cozy.ai.chat.assistants`
   document. When set, the response includes a `relationships` block.
+  When the assistant has a knowledge base folder, the retrieval is scoped to
+  that folder's workspace. The assistant's folder must have been indexed at
+  least once by the `rag-index` worker; otherwise the query fails with an
+  error event saying the knowledge base is not indexed.
 - `attachmentIDs` (optional) array of ids, specifying which documents should be leveraged by the RAG.
   
 

--- a/model/rag/chat.go
+++ b/model/rag/chat.go
@@ -466,14 +466,15 @@ func Query(inst *instance.Instance, logger logger.Logger, query QueryMessage) er
 		metadata["llm_override"] = override
 	}
 	if dirID := assistant.knowledgeBaseDirID(logger); dirID != "" {
-		if err := ensureWorkspace(inst, logger, dirID); err != nil {
-			logger.Warnf("cannot ensure RAG workspace %s: %s", dirID, err)
+		workspaceID := workspaceIDForDir(dirID)
+		if err := checkWorkspace(inst, workspaceID); err != nil {
+			logger.Warnf("RAG workspace %s unavailable: %s", workspaceID, err)
 			// A folder-scoped assistant must never answer from the whole
 			// instance: surface the error to the client and stop.
 			publishError(inst, msg.ID, err)
 			return err
 		}
-		metadata["workspace"] = dirID
+		metadata["workspace"] = workspaceID
 	}
 	payload := map[string]interface{}{
 		"model":       fmt.Sprintf("ragondin-%s", inst.Domain),

--- a/model/rag/checkpoint.go
+++ b/model/rag/checkpoint.go
@@ -1,0 +1,60 @@
+package rag
+
+import (
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/couchdb/revision"
+)
+
+// checkpoint is the per-trigger progress in the changes feed, stored in a
+// CouchDB local document of the indexed doctype's database.
+type checkpoint struct {
+	// LastSeq is the last sequence of the changes feed processed.
+	LastSeq string
+	// Retries counts the failed attempts at the batch starting after
+	// LastSeq. Reset to 0 when LastSeq advances.
+	Retries int
+}
+
+func loadCheckpoint(inst *instance.Instance, doctype, id string) (checkpoint, error) {
+	result, err := couchdb.GetLocal(inst, doctype, id)
+	if couchdb.IsNotFoundError(err) {
+		return checkpoint{}, nil
+	}
+	if err != nil {
+		return checkpoint{}, err
+	}
+	var cp checkpoint
+	cp.LastSeq, _ = result["last_seq"].(string)
+	if r, ok := result["retries"].(float64); ok {
+		cp.Retries = int(r)
+	}
+	return cp, nil
+}
+
+// saveCheckpoint writes the checkpoint, unless the stored sequence is more
+// recent than the one to save.
+func saveCheckpoint(inst *instance.Instance, doctype, id string, cp checkpoint) error {
+	result, err := couchdb.GetLocal(inst, doctype, id)
+	if err != nil {
+		if !couchdb.IsNotFoundError(err) {
+			return err
+		}
+		result = make(map[string]interface{})
+	} else if prev, ok := result["last_seq"].(string); ok {
+		if revision.Generation(cp.LastSeq) < revision.Generation(prev) {
+			return nil
+		}
+	}
+	result["last_seq"] = cp.LastSeq
+	result["retries"] = cp.Retries
+	return couchdb.PutLocal(inst, doctype, id, result)
+}
+
+func deleteCheckpoint(inst *instance.Instance, doctype, id string) error {
+	err := couchdb.DeleteLocal(inst, doctype, id)
+	if couchdb.IsNotFoundError(err) {
+		return nil
+	}
+	return err
+}

--- a/model/rag/errors.go
+++ b/model/rag/errors.go
@@ -1,0 +1,39 @@
+package rag
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+)
+
+// retryableError marks a failure that a later run may recover from (network
+// error, 5xx from openRAG). A batch hitting one keeps its checkpoint.
+type retryableError struct{ err error }
+
+func (e retryableError) Error() string { return e.err.Error() }
+func (e retryableError) Unwrap() error { return e.err }
+
+func retryable(err error) error {
+	if err == nil {
+		return nil
+	}
+	return retryableError{err: err}
+}
+
+func isRetryable(err error) bool {
+	var r retryableError
+	return errors.As(err, &r)
+}
+
+// statusError maps an openRAG response status to nil (2xx, or one of the
+// tolerated codes), a retryable error (5xx), or a plain error (other 4xx).
+func statusError(what string, status int, tolerated ...int) error {
+	if status < 300 || slices.Contains(tolerated, status) {
+		return nil
+	}
+	err := fmt.Errorf("%s status code: %d", what, status)
+	if status >= 500 {
+		return retryable(err)
+	}
+	return err
+}

--- a/model/rag/export_test.go
+++ b/model/rag/export_test.go
@@ -1,0 +1,33 @@
+package rag
+
+import (
+	"github.com/cozy/cozy-stack/model/instance"
+)
+
+// RootWorkspaceID is the openRAG workspace id of the root folder.
+const RootWorkspaceID = rootWorkspaceID
+
+// ReconcileWorkspacesForTest runs the workspace reconciliation against the
+// assistants of the instance, with own the folder of the running reconcile
+// job (only used when push is nil) and push the reconcile job hook.
+func ReconcileWorkspacesForTest(inst *instance.Instance, own string, push func(dirID string) error) error {
+	sc, err := loadScopes(inst, TestingLogger())
+	if err != nil {
+		return err
+	}
+	return reconcileWorkspaces(inst, TestingLogger(), inst.RAGServer(), sc, own, push)
+}
+
+// SetReconcilePushForTest replaces the reconcile job push; it returns a
+// function restoring the real one (call it in t.Cleanup).
+func SetReconcilePushForTest(fn func(inst *instance.Instance, dirID string) error) func() {
+	old := pushReconcile
+	pushReconcile = fn
+	return func() { pushReconcile = old }
+}
+
+// IsRetryableForTest tells whether the error asks for another attempt (a
+// transient failure), as opposed to one that is logged and skipped.
+func IsRetryableForTest(err error) bool {
+	return isRetryable(err)
+}

--- a/model/rag/helpers_test.go
+++ b/model/rag/helpers_test.go
@@ -1,0 +1,433 @@
+package rag
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/logger"
+)
+
+type RecordedRequest struct {
+	Method string
+	Path   string
+	Body   []byte
+}
+
+type RequestRecorder struct {
+	mu       sync.Mutex
+	requests []RecordedRequest
+}
+
+func (r *RequestRecorder) record(req *http.Request) {
+	body, _ := io.ReadAll(req.Body)
+	req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	r.mu.Lock()
+	r.requests = append(r.requests, RecordedRequest{Method: req.Method, Path: req.URL.Path, Body: body})
+	r.mu.Unlock()
+}
+
+func (r *RequestRecorder) All() []RecordedRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]RecordedRequest, len(r.requests))
+	copy(out, r.requests)
+	return out
+}
+
+func (r *RequestRecorder) Count(method, p string) int {
+	n := 0
+	for _, rr := range r.All() {
+		if rr.Method == method && rr.Path == p {
+			n++
+		}
+	}
+	return n
+}
+
+func TestingLogger() logger.Logger {
+	return logger.WithNamespace("rag-test")
+}
+
+func newRAGTestServer(t *testing.T, handler http.HandlerFunc) (config.RAGServer, *RequestRecorder) {
+	t.Helper()
+	rec := &RequestRecorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		rec.record(req)
+		handler(w, req)
+	}))
+	t.Cleanup(srv.Close)
+	return config.RAGServer{URL: srv.URL, APIKey: "test-key"}, rec
+}
+
+// FakeFile is the state openRAG keeps for one indexed file.
+type FakeFile struct {
+	MD5 string
+	// Sha is the sha256 of the content openRAG received, what it
+	// deduplicates on inside a partition. It is empty for a file declared
+	// with AddFile, which never carried a content.
+	Sha        string
+	Workspaces []string
+}
+
+// FakeOpenRAG is an in-memory openRAG implementing the routes the stack uses.
+type FakeOpenRAG struct {
+	t          *testing.T
+	Server     config.RAGServer
+	Rec        *RequestRecorder
+	mu         sync.Mutex
+	files      map[string]*FakeFile
+	workspaces map[string]bool
+	// pending holds the ids openRAG has accepted but not indexed yet: a POST
+	// on them conflicts, while a GET still answers 404.
+	pending map[string]bool
+	// Fail, when set, is consulted before every request: a non-zero status
+	// is returned as-is without touching the state. Typical use, a file the
+	// indexer refuses for good:
+	//
+	//	f.Fail = func(method, path string) int {
+	//		if method == http.MethodPost && path == uploadPath {
+	//			return http.StatusUnsupportedMediaType
+	//		}
+	//		return 0
+	//	}
+	Fail func(method, path string) int
+}
+
+func NewFakeOpenRAG(t *testing.T) *FakeOpenRAG {
+	t.Helper()
+	f := &FakeOpenRAG{t: t, files: map[string]*FakeFile{}, workspaces: map[string]bool{}, pending: map[string]bool{}}
+	f.Server, f.Rec = newRAGTestServer(t, f.handle)
+	return f
+}
+
+func (f *FakeOpenRAG) AddFile(id, md5 string, workspaces ...string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.files[id] = &FakeFile{MD5: md5, Workspaces: append([]string{}, workspaces...)}
+}
+
+// AddPendingFile declares a file whose indexing task is still running on
+// openRAG: a POST on its id conflicts, but a GET on the file answers 404
+// until the task completes (or a PUT re-indexes it).
+func (f *FakeOpenRAG) AddPendingFile(id string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pending[id] = true
+}
+
+func (f *FakeOpenRAG) AddWorkspace(id string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.workspaces[id] = true
+}
+
+func (f *FakeOpenRAG) File(id string) (FakeFile, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ff, ok := f.files[id]
+	if !ok {
+		return FakeFile{}, false
+	}
+	return FakeFile{MD5: ff.MD5, Sha: ff.Sha, Workspaces: append([]string{}, ff.Workspaces...)}, true
+}
+
+func (f *FakeOpenRAG) HasWorkspace(id string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.workspaces[id]
+}
+
+func (f *FakeOpenRAG) FileIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ids := make([]string, 0, len(f.files))
+	for id := range f.files {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// contentSha is the sha256 of the uploaded content, what openRAG
+// deduplicates on inside a partition.
+func contentSha(req *http.Request) (string, error) {
+	part, _, err := req.FormFile("file")
+	if err != nil {
+		return "", err
+	}
+	defer part.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, part); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// fileWithContent returns the id of another file holding that content, empty
+// when the partition has none. The caller holds the lock.
+func (f *FakeOpenRAG) fileWithContent(sha, exceptID string) string {
+	if sha == "" {
+		return ""
+	}
+	for id, ff := range f.files {
+		if id != exceptID && ff.Sha == sha {
+			return id
+		}
+	}
+	return ""
+}
+
+// validWorkspaceID is what openRAG accepts as a workspace id: it answers
+// 422 on anything else, so a folder id with a dot (the root folder id) can
+// never be a workspace id.
+var validWorkspaceID = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// handle routes (after url decoding of the path segments):
+//
+//	GET    /partition/{d}/                         → {"files":[{"link":".../partition/{d}/file/{id}"}]}
+//	DELETE /partition/{d}                          → 204, drops every file and workspace
+//	POST   /partition/{d}                          → 201
+//	GET    /partition/{d}/file/{id}                → {"metadata":{"md5sum":..}} | 404
+//	POST   /indexer/partition/{d}/file/{id}        → 201 (multipart, reads workspace_ids, md5sum from query)
+//	                                                 | 409 on a known or pending id
+//	                                                 | 409 DOCUMENT_CONTENT_EXISTS when another
+//	                                                   file of the partition holds that content
+//	PUT    /indexer/partition/{d}/file/{id}        → 202 on a known or pending id | 404
+//	DELETE /indexer/partition/{d}/file/{id}        → 200 | 404
+//	GET    /partition/{d}/workspaces               → {"workspaces":[{"workspace_id":..}]}
+//	GET    /partition/{d}/workspaces/{ws}          → 200 | 404
+//	POST   /partition/{d}/workspaces               → 201 | 409
+//	DELETE /partition/{d}/workspaces/{ws}          → 200 | 404, and deletes the
+//	                                                  files left without workspace
+//	GET    /partition/{d}/files/{id}/workspaces    → {"workspace_ids":[..]} | 404
+//	POST   /partition/{d}/workspaces/{ws}/files    → 200 | 404 (unknown ws or any unknown id)
+//	DELETE /partition/{d}/workspaces/{ws}/files/{id} → 200 | 404
+func (f *FakeOpenRAG) handle(w http.ResponseWriter, req *http.Request) {
+	if f.Fail != nil {
+		if status := f.Fail(req.Method, req.URL.Path); status != 0 {
+			writeJSON(w, status, map[string]string{"error": "injected"})
+			return
+		}
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	segs := strings.Split(strings.Trim(req.URL.Path, "/"), "/")
+	trailingSlash := strings.HasSuffix(req.URL.Path, "/")
+	switch {
+	case req.Method == http.MethodGet && len(segs) == 2 && segs[0] == "partition" && trailingSlash:
+		links := []map[string]string{}
+		for id := range f.files {
+			links = append(links, map[string]string{"link": fmt.Sprintf("%s/partition/%s/file/%s", f.Server.URL, segs[1], id)})
+		}
+		writeJSON(w, 200, map[string]interface{}{"files": links})
+	case req.Method == http.MethodPost && len(segs) == 2 && segs[0] == "partition":
+		writeJSON(w, 201, map[string]string{})
+	case req.Method == http.MethodDelete && len(segs) == 2 && segs[0] == "partition":
+		f.files = map[string]*FakeFile{}
+		f.workspaces = map[string]bool{}
+		f.pending = map[string]bool{}
+		w.WriteHeader(204)
+	case len(segs) == 4 && segs[0] == "partition" && segs[2] == "file":
+		ff, ok := f.files[segs[3]]
+		if req.Method != http.MethodGet {
+			writeJSON(w, 405, nil)
+		} else if !ok {
+			writeJSON(w, 404, nil)
+		} else {
+			writeJSON(w, 200, map[string]interface{}{"metadata": map[string]string{"md5sum": ff.MD5}})
+		}
+	case len(segs) == 5 && segs[0] == "indexer" && segs[1] == "partition" && segs[3] == "file":
+		id := segs[4]
+		switch req.Method {
+		case http.MethodDelete:
+			if _, ok := f.files[id]; !ok {
+				delete(f.pending, id)
+				writeJSON(w, 404, nil)
+				return
+			}
+			delete(f.files, id)
+			delete(f.pending, id)
+			writeJSON(w, 200, map[string]string{})
+		case http.MethodPost, http.MethodPut:
+			_, known := f.files[id]
+			if req.Method == http.MethodPost && (known || f.pending[id]) {
+				// openRAG refuses to index an id it already holds, even
+				// when its indexing task is still running.
+				writeJSON(w, 409, map[string]string{
+					"detail": fmt.Sprintf("File '%s' already exists in partition %s", id, segs[2]),
+				})
+				return
+			}
+			if req.Method == http.MethodPut && !known && !f.pending[id] {
+				// A PUT is a re-index: openRAG does not create the file.
+				writeJSON(w, 404, map[string]string{
+					"detail": fmt.Sprintf("'%s' not found in partition '%s'", id, segs[2]),
+				})
+				return
+			}
+			if err := req.ParseMultipartForm(1 << 20); err != nil {
+				writeJSON(w, 400, map[string]string{"error": err.Error()})
+				return
+			}
+			sha, err := contentSha(req)
+			if err != nil {
+				writeJSON(w, 400, map[string]string{"error": err.Error()})
+				return
+			}
+			if req.Method == http.MethodPost {
+				if other := f.fileWithContent(sha, id); other != "" {
+					// openRAG indexes one document per distinct content in a
+					// partition: this id will never be indexed.
+					writeJSON(w, 409, map[string]interface{}{
+						"detail": fmt.Sprintf("[DOCUMENT_CONTENT_EXISTS]: This document already exists in partition '%s'.", segs[2]),
+						"extra": map[string]string{
+							"existing_file_id": other,
+							"request_id":       "fake-" + id,
+						},
+					})
+					return
+				}
+			}
+			var wsIDs []string
+			if raw := req.FormValue("workspace_ids"); raw != "" {
+				if err := json.Unmarshal([]byte(raw), &wsIDs); err != nil {
+					writeJSON(w, 400, map[string]string{"error": err.Error()})
+					return
+				}
+				for _, ws := range wsIDs {
+					if !f.workspaces[ws] {
+						writeJSON(w, 404, map[string]string{"error": "unknown workspace " + ws})
+						return
+					}
+				}
+			}
+			f.files[id] = &FakeFile{MD5: req.URL.Query().Get("md5sum"), Sha: sha, Workspaces: wsIDs}
+			delete(f.pending, id)
+			if req.Method == http.MethodPost {
+				writeJSON(w, 201, map[string]interface{}{"task_status_url": "/task/" + id})
+				return
+			}
+			writeJSON(w, 202, map[string]interface{}{"task_status_url": "/task/" + id})
+		default:
+			writeJSON(w, 405, nil)
+		}
+	case req.Method == http.MethodGet && len(segs) == 3 && segs[0] == "partition" && segs[2] == "workspaces":
+		list := []map[string]string{}
+		for id := range f.workspaces {
+			list = append(list, map[string]string{"workspace_id": id})
+		}
+		writeJSON(w, 200, map[string]interface{}{"workspaces": list})
+	case req.Method == http.MethodPost && len(segs) == 3 && segs[0] == "partition" && segs[2] == "workspaces":
+		var body struct {
+			WorkspaceID string `json:"workspace_id"`
+		}
+		_ = json.NewDecoder(req.Body).Decode(&body)
+		if !validWorkspaceID.MatchString(body.WorkspaceID) {
+			// openRAG validates the id and answers 422 (FastAPI style).
+			writeJSON(w, 422, map[string]interface{}{"detail": []map[string]interface{}{{
+				"loc":  []string{"body", "workspace_id"},
+				"msg":  "workspace_id must be non-empty and contain only alphanumeric characters, hyphens, or underscores",
+				"type": "value_error",
+			}}})
+			return
+		}
+		if f.workspaces[body.WorkspaceID] {
+			writeJSON(w, 409, nil)
+			return
+		}
+		f.workspaces[body.WorkspaceID] = true
+		writeJSON(w, 201, map[string]string{})
+	case len(segs) == 4 && segs[0] == "partition" && segs[2] == "workspaces":
+		ws := segs[3]
+		switch req.Method {
+		case http.MethodGet:
+			if f.workspaces[ws] {
+				writeJSON(w, 200, map[string]string{"workspace_id": ws})
+			} else {
+				writeJSON(w, 404, nil)
+			}
+		case http.MethodDelete:
+			if !f.workspaces[ws] {
+				writeJSON(w, 404, nil)
+				return
+			}
+			delete(f.workspaces, ws)
+			for id, ff := range f.files {
+				if !slices.Contains(ff.Workspaces, ws) {
+					continue
+				}
+				ff.Workspaces = slices.DeleteFunc(ff.Workspaces, func(s string) bool { return s == ws })
+				if len(ff.Workspaces) == 0 {
+					// Like openRAG: a member left in no workspace is deleted.
+					delete(f.files, id)
+				}
+			}
+			writeJSON(w, 200, map[string]string{})
+		default:
+			writeJSON(w, 405, nil)
+		}
+	case req.Method == http.MethodGet && len(segs) == 5 && segs[0] == "partition" && segs[2] == "files" && segs[4] == "workspaces":
+		ff, ok := f.files[segs[3]]
+		if !ok {
+			writeJSON(w, 404, nil)
+			return
+		}
+		writeJSON(w, 200, map[string]interface{}{"workspace_ids": ff.Workspaces})
+	case req.Method == http.MethodPost && len(segs) == 5 && segs[0] == "partition" && segs[2] == "workspaces" && segs[4] == "files":
+		ws := segs[3]
+		if !f.workspaces[ws] {
+			writeJSON(w, 404, nil)
+			return
+		}
+		var body struct {
+			FileIDs []string `json:"file_ids"`
+		}
+		_ = json.NewDecoder(req.Body).Decode(&body)
+		for _, id := range body.FileIDs {
+			if _, ok := f.files[id]; !ok {
+				writeJSON(w, 404, map[string]string{"error": "unknown file " + id})
+				return
+			}
+		}
+		for _, id := range body.FileIDs {
+			ff := f.files[id]
+			if !slices.Contains(ff.Workspaces, ws) {
+				ff.Workspaces = append(ff.Workspaces, ws)
+			}
+		}
+		writeJSON(w, 200, map[string]string{})
+	case req.Method == http.MethodDelete && len(segs) == 6 && segs[0] == "partition" && segs[2] == "workspaces" && segs[4] == "files":
+		ws, id := segs[3], segs[5]
+		ff, ok := f.files[id]
+		if !ok || !f.workspaces[ws] || !slices.Contains(ff.Workspaces, ws) {
+			writeJSON(w, 404, nil)
+			return
+		}
+		ff.Workspaces = slices.DeleteFunc(ff.Workspaces, func(s string) bool { return s == ws })
+		writeJSON(w, 200, map[string]string{})
+	default:
+		f.t.Logf("fake openRAG: unhandled %s %s", req.Method, req.URL.Path)
+		writeJSON(w, 404, map[string]string{"error": "unhandled " + req.Method + " " + path.Clean(req.URL.Path)})
+	}
+}

--- a/model/rag/index.go
+++ b/model/rag/index.go
@@ -11,8 +11,9 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
-	"sync"
+	"time"
 
 	"github.com/cozy/cozy-stack/model/feature"
 	"github.com/cozy/cozy-stack/model/instance"
@@ -22,95 +23,519 @@ import (
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/cozy/cozy-stack/pkg/couchdb"
-	"github.com/cozy/cozy-stack/pkg/couchdb/revision"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/labstack/echo/v4"
 )
 
-// BatchSize is the maximal number of documents manipulated at once by the
-// worker.
-const BatchSize = 100
+const (
+	// BatchSize is the maximal number of documents manipulated at once by the
+	// worker.
+	BatchSize = 100
+	// MaxBatchRetries caps the attempts at a batch that keeps failing on
+	// retryable errors, so one poisoned file cannot stall a trigger. The
+	// worker retries a failed job MaxExecCount times (3, see worker/rag), and
+	// every execution consumes one attempt: 15 is about five trigger firings.
+	MaxBatchRetries = 15
+	workerType      = "rag-index"
+	// indexLockName serializes the rag-index jobs of an instance.
+	indexLockName = "index/" + consts.Files
+	// checkpointDocID is the CouchDB local document holding the checkpoint.
+	checkpointDocID = "rag-index"
+)
 
+// IndexMessage is the message of rag-index triggers and jobs. Without
+// ReconcileDirID the job processes the changes feed; with it, the job walks
+// the folder's subtree (initial indexing of a new knowledge base folder).
 type IndexMessage struct {
-	Doctype string `json:"doctype"`
+	Doctype        string `json:"doctype"`
+	ReconcileDirID string `json:"reconcile_dir_id,omitempty"`
 }
 
+// Index is the entry point of the rag-index worker.
 func Index(inst *instance.Instance, logger logger.Logger, msg IndexMessage) error {
 	if msg.Doctype != consts.Files {
 		return errors.New("Only file can be indexed for the moment")
 	}
+	server := inst.RAGServer()
+	if server.URL == "" {
+		return errors.New("no RAG server configured")
+	}
 
-	mu := config.Lock().ReadWrite(inst, "index/"+msg.Doctype)
+	mu := config.Lock().LongOperation(inst, indexLockName)
 	if err := mu.Lock(); err != nil {
 		return err
 	}
 	defer mu.Unlock()
 
-	lastSeq, err := getLastSeqNumber(inst, msg.Doctype)
+	ctx := &indexContext{inst: inst, logger: logger, server: server}
+	// An error only means some sources were unreachable, the flags are usable.
+	ctx.flags, _ = feature.GetFlags(inst)
+	sc, err := loadScopes(inst, logger)
 	if err != nil {
 		return err
 	}
-	feed, err := callChangesFeed(inst, msg.Doctype, lastSeq)
+	ctx.scopes = sc
+
+	// A reconcile job must not spawn reconcile jobs: it is the one doing the
+	// walk, and a workspace whose creation keeps failing would loop. A nil
+	// push also bounds the reconciliation to the job's own folder.
+	var push func(string) error
+	if msg.ReconcileDirID == "" {
+		push = func(dirID string) error { return pushReconcile(inst, dirID) }
+	}
+	if err := reconcileWorkspaces(inst, logger, server, sc, msg.ReconcileDirID, push); err != nil {
+		if isRetryable(err) {
+			// The workspaces of the partition could not be listed, or a
+			// removal failed on a transient error: the view is partial, so
+			// nothing was detached on a guess and the batch must not run
+			// against workspaces that may not exist.
+			return err
+		}
+		// Definitive removal failures: reported, retried next run; the batch
+		// still runs.
+		logger.Warnf("workspace reconciliation: %s", err)
+	}
+
+	if msg.ReconcileDirID != "" {
+		return ctx.reconcileFolder(msg.ReconcileDirID)
+	}
+
+	cp, err := loadCheckpoint(inst, consts.Files, checkpointDocID)
 	if err != nil {
 		return err
 	}
-	if feed.LastSeq == lastSeq {
+	feed, err := callChangesFeed(inst, consts.Files, cp.LastSeq)
+	if err != nil {
+		return err
+	}
+	if feed.LastSeq == cp.LastSeq {
 		return nil
 	}
-
-	// Lazily loaded on first use, so batches that never reconcile workspace
-	// membership (e.g. deletions only) skip the CouchDB and openRAG queries.
-	kb := sync.OnceValue(func() *kbContext { return loadKBContext(inst, logger) })
-
-	var errj error
-	for _, change := range feed.Results {
-		if err := callRAGIndexer(inst, msg.Doctype, change, kb, logger); err != nil {
-			logger.Warnf("Index error: %s", err)
-			errj = errors.Join(errj, err)
-		}
-	}
-	_ = updateLastSequenceNumber(inst, msg.Doctype, feed.LastSeq)
-
-	if feed.Pending > 0 {
-		_ = pushJob(inst, msg.Doctype)
-	}
-
-	return errj
+	return ctx.runBatch(cp, feed)
 }
 
-func callRAGIndexer(inst *instance.Instance, doctype string, change couchdb.Change, kb func() *kbContext, logger logger.Logger) error {
+// indexContext is the state of one rag-index run.
+type indexContext struct {
+	inst   *instance.Instance
+	logger logger.Logger
+	server config.RAGServer
+	flags  *feature.Flags
+	scopes *scopes
+}
+
+// runBatch processes the (at most BatchSize) changes of the feed loaded after
+// the checkpoint, then advances the checkpoint unless the batch must be
+// retried.
+func (ctx *indexContext) runBatch(cp checkpoint, feed *couchdb.ChangesResponse) error {
+	var errj error
+	var failed []string
+	retry := false
+	for _, change := range feed.Results {
+		if err := ctx.handleChange(change); err != nil {
+			if errors.Is(err, errDuplicateContent) {
+				// openRAG will never index that content twice: indexFile
+				// logged it, and the batch has nothing to report or replay.
+				continue
+			}
+			ctx.logger.Warnf("Index error on %s: %s", change.DocID, err)
+			errj = errors.Join(errj, err)
+			failed = append(failed, change.DocID)
+			if isRetryable(err) {
+				retry = true
+			}
+		}
+	}
+
+	if retry && cp.Retries < MaxBatchRetries {
+		cp.Retries++
+		if err := saveCheckpoint(ctx.inst, consts.Files, checkpointDocID, cp); err != nil {
+			errj = errors.Join(errj, err)
+		}
+		return errj
+	}
+	if retry {
+		ctx.logger.Errorf("Giving up on the batch after %s after %d attempts on %v: %s",
+			cp.LastSeq, cp.Retries+1, failed, errj)
+	}
+	cp.LastSeq = feed.LastSeq
+	cp.Retries = 0
+	if err := saveCheckpoint(ctx.inst, consts.Files, checkpointDocID, cp); err != nil {
+		return errors.Join(errj, err)
+	}
+	if feed.Pending > 0 {
+		_ = pushJob(ctx.inst, IndexMessage{Doctype: consts.Files})
+	}
+	if retry {
+		// Gave up: the job must still report the batch as failed.
+		return errj
+	}
+	// Any remaining failure was non-retryable: it was logged and skipped, and
+	// the batch is done. Failing the job would only replay it for nothing.
+	return nil
+}
+
+func (ctx *indexContext) handleChange(change couchdb.Change) error {
 	if strings.HasPrefix(change.DocID, "_design/") {
 		return nil
 	}
-
 	if change.Doc.Get("type") == consts.DirType {
-		// Moving a directory rewrites the path of every descendant directory
-		// but never touches the file docs, which may have silently entered or
-		// left a knowledge-base folder. Each descendant shows up in this same
-		// feed, so reconciling the direct children covers the whole subtree.
-		dirPath, _ := change.Doc.Get("path").(string)
-		if dirPath != "" && !strings.HasPrefix(dirPath, vfs.TrashDirName) {
-			reconcileDirChildren(inst, logger, kb(), change.DocID, dirPath)
-		}
+		return ctx.handleDirChange(change)
+	}
+	if change.Deleted || change.Doc.Get("trashed") == true {
+		return deleteFromRAG(ctx.inst, change.DocID)
+	}
+	return ctx.handleFile(fileInfoFromChange(change))
+}
+
+// handleDirChange reacts to a directory document change (typically a move
+// or a rename): the file documents of the subtree do not change, so the
+// direct file children of every changed directory are re-evaluated against
+// the scope. Descendant directories show up in the same feed.
+func (ctx *indexContext) handleDirChange(change couchdb.Change) error {
+	if strings.HasPrefix(change.Doc.Rev(), "1-") {
+		return nil // a new directory is empty
+	}
+	dirPath, _ := change.Doc.Get("path").(string)
+	if dirPath == "" {
 		return nil
 	}
+	ctx.scopes.dirs[change.DocID] = dirPath
+	iter := ctx.inst.VFS().DirIterator(&vfs.DirDoc{DocID: change.DocID, Fullpath: dirPath}, nil)
+	var errj error
+	for {
+		_, file, err := iter.Next()
+		if errors.Is(err, vfs.ErrIteratorDone) {
+			return errj
+		}
+		if err != nil {
+			// The remaining children were not evaluated against the scope,
+			// and nothing else will bring them back: hold the checkpoint so
+			// the whole directory is re-listed on the next run.
+			return errors.Join(errj, retryable(err))
+		}
+		if file == nil || file.Trashed {
+			continue
+		}
+		if err := ctx.handleFile(fileInfoFromDoc(file)); err != nil && !errors.Is(err, errDuplicateContent) {
+			errj = errors.Join(errj, err)
+		}
+	}
+}
 
-	// An error only means some sources were unreachable, the flags are usable.
-	flags, _ := feature.GetFlags(inst)
-	if inst.RAGServer().URL == "" {
-		return errors.New("no RAG server configured")
+// handleFile applies the scope rule to one live file: it must be indexed in
+// the workspace of every knowledge base folder containing it, and must not
+// be on openRAG at all when no folder contains it.
+func (ctx *indexContext) handleFile(f fileInfo) error {
+	parentPath, err := ctx.scopes.dirs.path(ctx.inst.VFS(), f.DirID)
+	if errors.Is(err, os.ErrNotExist) {
+		ctx.logger.Warnf("parent directory %s of file %s is gone: skipped", f.DirID, f.ID)
+		return nil
+	}
+	if err != nil {
+		// Unknown scope: hold the checkpoint rather than guess.
+		return retryable(err)
+	}
+	desired := ctx.scopes.desiredFor(parentPath)
+	if len(desired) > 0 {
+		return ctx.indexFile(f, desired)
+	}
+	if f.fromFeed && strings.HasPrefix(f.Rev, "1-") {
+		// The file document was created after the checkpoint and is out of
+		// scope: it was never indexed, no need to ask openRAG. A file reached
+		// through a directory change does not qualify: moving its parent
+		// leaves it at rev 1- even though it may well be indexed.
+		return nil
+	}
+	return deleteFromRAG(ctx.inst, f.ID)
+}
+
+// indexFile sends the file to the indexer when openRAG does not hold its
+// current content, and keeps its memberships equal to desired (the ids of
+// the knowledge base folders containing the file, mapped to workspace ids).
+func (ctx *indexContext) indexFile(f fileInfo, desired []string) error {
+	if !isClassAllowed(ctx.flags, f.Class) {
+		return SetIndexStatus(ctx.inst, f.ID, StatusNotSupported, f.Rev)
+	}
+	needed, isNew, err := needsIndexation(ctx.inst, f.ID, f.MD5)
+	if err != nil {
+		return err
+	}
+	// openRAG knows the folders by their workspace id.
+	workspaceIDs := workspaceIDsForDirs(desired)
+	if !needed {
+		return syncMembership(ctx.server, ctx.inst.Domain, f.ID, workspaceIDs)
 	}
 
-	class, _ := change.Doc.Get("class").(string)
-	if !isClassAllowed(flags, class) {
-		rev, _ := change.Doc.Get("_rev").(string)
-		return SetIndexStatus(inst, change.DocID, StatusNotSupported, rev)
+	workspaces, err := json.Marshal(workspaceIDs)
+	if err != nil {
+		return err
 	}
+	name, content, err := resolveContent(ctx.inst, f)
+	if err != nil {
+		return contentUnavailable(f.ID, err)
+	}
+	up := ragUpload{
+		Server:      ctx.server,
+		Domain:      ctx.inst.Domain,
+		FileID:      f.ID,
+		Name:        name,
+		DirID:       f.DirID,
+		MD5Sum:      f.MD5,
+		Meta:        uploadMeta(f),
+		Workspaces:  string(workspaces),
+		CallbackURL: ctx.inst.PageURL(IndexStatusPath, nil),
+		IsNew:       isNew,
+	}
+	status, body, err := sendUpload(up, content)
+	if err != nil {
+		return retryable(err)
+	}
+	if status == http.StatusConflict {
+		conflict, existingID := classifyConflict(body)
+		switch {
+		case conflict == conflictContentExists:
+			// openRAG holds one document per distinct content in a
+			// partition: this file id will never be indexed, and a PUT on
+			// it would answer 404. There is nothing to try, now or later —
+			// a PUT that is refused the same way is as definitive.
+			if existingID == "" {
+				existingID = "another file"
+			}
+			ctx.logger.Infof("file %s (%s) has the same content as %s already indexed: skipped",
+				f.ID, f.Name, existingID)
+			return errDuplicateContent
+		case conflict == conflictIDExists && isNew:
+			// openRAG already holds the file id: either the indexing of a
+			// previous upload is still running (it answers 404 on the file
+			// until the task completes) or a POST was lost on the way back.
+			// Both are fixed by a PUT, which re-indexes the content.
+			ctx.logger.Infof("file %s is already on the RAG server: uploading it again with a PUT", f.ID)
+			// The reader of the first attempt was consumed.
+			if _, content, err = resolveContent(ctx.inst, f); err != nil {
+				return contentUnavailable(f.ID, err)
+			}
+			up.IsNew = false
+			isNew = false
+			if status, _, err = sendUpload(up, content); err != nil {
+				return retryable(err)
+			}
+		}
+	}
+	if err := statusError("upload", status); err != nil {
+		return err
+	}
+	if !isNew {
+		// A PUT re-embeds the content: make sure the memberships survived it.
+		return syncMembership(ctx.server, ctx.inst.Domain, f.ID, workspaceIDs)
+	}
+	return nil
+}
 
-	if change.Deleted || change.Doc.Get("trashed") == true {
-		return deleteFromRAG(inst, change.DocID)
+// sendUpload sends one upload request and returns its status code with the
+// beginning of the body openRAG answered (what tells its two 409 apart). It
+// always closes the content.
+func sendUpload(up ragUpload, content io.ReadCloser) (int, []byte, error) {
+	defer content.Close()
+	res, err := uploadToRAG(up, content)
+	if err != nil {
+		return 0, nil, err
 	}
-	return upsertToRAG(inst, doctype, change, kb, logger)
+	defer res.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(res.Body, maxErrorBody))
+	_, _ = io.Copy(io.Discard, res.Body)
+	return res.StatusCode, body, nil
+}
+
+// maxErrorBody bounds what is read from the body of an upload response: it is
+// read on every response, but only to classify a failure, and openRAG answers
+// a short JSON.
+const maxErrorBody = 4096
+
+// errDuplicateContent is the file openRAG will never index: another document
+// of the partition already holds that content. It is a definitive skip, not a
+// failure, and callers count it apart.
+var errDuplicateContent = errors.New("content already indexed under another file id")
+
+// uploadConflict is what a 409 of the upload route means.
+type uploadConflict int
+
+const (
+	// conflictUnknown is a 409 whose body says nothing the stack knows.
+	conflictUnknown uploadConflict = iota
+	// conflictIDExists: openRAG already holds that file id (indexed, or its
+	// indexing task still running). A PUT re-indexes it.
+	conflictIDExists
+	// conflictContentExists: another id of the partition already holds that
+	// content. openRAG deduplicates by content, so this id stays unindexed.
+	conflictContentExists
+)
+
+// duplicateContentCode is the marker openRAG puts in the detail of the 409 it
+// answers on an upload whose content is already indexed under another id.
+const duplicateContentCode = "DOCUMENT_CONTENT_EXISTS"
+
+// ragError is the error body of openRAG (FastAPI): a detail, and the extra
+// fields of the errors that carry one.
+type ragError struct {
+	Detail string `json:"detail"`
+	Extra  struct {
+		ExistingFileID string `json:"existing_file_id"`
+	} `json:"extra"`
+}
+
+// classifyConflict tells the two 409 of the upload route apart, and returns
+// the id of the document already holding the content for the second one:
+//
+//	{"detail": "File '<id>' already exists in partition <d>"}
+//	{"detail": "[DOCUMENT_CONTENT_EXISTS]: This document already exists in
+//	 partition '<d>'.", "extra": {"existing_file_id": "<other id>"}}
+func classifyConflict(body []byte) (uploadConflict, string) {
+	var ragErr ragError
+	if err := json.Unmarshal(body, &ragErr); err != nil {
+		// Not the expected shape (a FastAPI validation detail is a list, and
+		// a proxy may answer something that is not JSON at all): the raw body
+		// is all there is to look at.
+		ragErr.Detail = string(body)
+	}
+	switch {
+	// The content case comes first: its detail also contains "already
+	// exists", so the other order would classify every duplicate as an id
+	// conflict and send a PUT that answers 404.
+	case strings.Contains(ragErr.Detail, duplicateContentCode):
+		return conflictContentExists, ragErr.Extra.ExistingFileID
+	case strings.Contains(ragErr.Detail, "already exists"):
+		return conflictIDExists, ""
+	default:
+		return conflictUnknown, ""
+	}
+}
+
+// reconcileFolder walks a folder's subtree and applies the scope rule to
+// every live file: the initial indexing of a new knowledge base folder.
+func (ctx *indexContext) reconcileFolder(dirID string) error {
+	dir, err := ctx.inst.VFS().DirByID(dirID)
+	if errors.Is(err, os.ErrNotExist) {
+		ctx.logger.Warnf("reconcile: folder %s does not exist", dirID)
+		return nil
+	}
+	if err != nil {
+		return retryable(err)
+	}
+	// Per-file failures follow the rule of runBatch: a transient one fails
+	// the job so that the folder is walked again, a definitive one (the
+	// indexer refusing that file) is logged and skipped. Failing the job on
+	// the latter would only replay the same walk to the same refusal.
+	var firstTransient error
+	var indexed, transient, duplicates, skipped int
+	err = vfs.WalkAlreadyLocked(ctx.inst.VFS(), dir, func(_ string, _ *vfs.DirDoc, file *vfs.FileDoc, err error) error {
+		if err != nil {
+			return err
+		}
+		if file == nil || file.Trashed {
+			return nil
+		}
+		switch err := ctx.handleFile(fileInfoFromDoc(file)); {
+		case err == nil:
+			indexed++
+		case errors.Is(err, errDuplicateContent):
+			// A whole Drive holds hundreds of them: indexFile logged the
+			// file once, at info, and the walk only counts it here.
+			duplicates++
+		case isRetryable(err):
+			ctx.logger.Warnf("reconcile: file %s failed on a transient error: %s", file.DocID, err)
+			transient++
+			if firstTransient == nil {
+				firstTransient = err
+			}
+		default:
+			ctx.logger.Warnf("reconcile: file %s skipped: %s", file.DocID, err)
+			skipped++
+		}
+		return nil
+	})
+	if err != nil {
+		// The subtree was not walked entirely: nothing else replays it.
+		return retryable(err)
+	}
+	summary := fmt.Sprintf("reconcile: folder %s walked: %d file(s) indexed or up to date, %d duplicate(s) skipped, %d refused",
+		dirID, indexed, duplicates, skipped)
+	if skipped > 0 {
+		ctx.logger.Warn(summary)
+	} else {
+		ctx.logger.Info(summary)
+	}
+	if firstTransient != nil {
+		return retryable(fmt.Errorf("reconcile: %d file(s) of folder %s failed on a transient error, first: %w",
+			transient, dirID, firstTransient))
+	}
+	return nil
+}
+
+// uploadMeta is the metadata form field of an upload, what the RAG server
+// stores alongside the file and returns on its search hits.
+func uploadMeta(f fileInfo) map[string]string {
+	datetime, _ := f.Metadata["datetime"].(string)
+	return map[string]string{
+		"md5sum":     f.MD5,
+		"datetime":   datetime,
+		"created_at": f.CreatedAt,
+		"doctype":    consts.Files,
+		// Echoed back by the indexer on the callback, which is ordered on it.
+		"doc_rev": f.Rev,
+	}
+}
+
+// fileInfo is the subset of a file document the indexer needs, built either
+// from a changes feed entry or from a VFS document.
+type fileInfo struct {
+	ID, Rev, DirID, Name, Mime, Class, MD5, InternalID string
+	// CreatedAt is the creation date of the document in RFC 3339, as CouchDB
+	// stores it (empty when the document has none).
+	CreatedAt string
+	Metadata  map[string]interface{}
+	// fromFeed tells that the file document itself is one of the changes of
+	// the batch, as opposed to being reached by iterating a changed
+	// directory. Only then does its revision say something about how recent
+	// the file is.
+	fromFeed bool
+}
+
+func fileInfoFromChange(change couchdb.Change) fileInfo {
+	doc := change.Doc
+	f := fileInfo{ID: change.DocID, Rev: doc.Rev(), fromFeed: true}
+	f.DirID, _ = doc.Get("dir_id").(string)
+	f.Name, _ = doc.Get("name").(string)
+	f.Mime, _ = doc.Get("mime").(string)
+	f.Class, _ = doc.Get("class").(string)
+	f.InternalID, _ = doc.Get("internal_vfs_id").(string)
+	f.CreatedAt, _ = doc.Get("created_at").(string)
+	f.MD5 = decodeMD5Sum(doc.Get("md5sum"))
+	f.Metadata, _ = doc.Get("metadata").(map[string]interface{})
+	return f
+}
+
+func fileInfoFromDoc(doc *vfs.FileDoc) fileInfo {
+	return fileInfo{
+		ID:         doc.DocID,
+		Rev:        doc.DocRev,
+		DirID:      doc.DirID,
+		Name:       doc.DocName,
+		Mime:       doc.Mime,
+		Class:      doc.Class,
+		InternalID: doc.InternalID,
+		CreatedAt:  formatCreatedAt(doc.CreatedAt),
+		MD5:        hex.EncodeToString(doc.MD5Sum),
+		Metadata:   map[string]interface{}(doc.Metadata),
+	}
+}
+
+// formatCreatedAt serializes a creation date the way CouchDB carries it, so
+// that both fileInfo constructors give the RAG server the same value.
+func formatCreatedAt(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
 }
 
 func isClassAllowed(flags *feature.Flags, class string) bool {
@@ -139,17 +564,18 @@ func deleteFromRAGHTTP(server config.RAGServer, domain, fileID string) error {
 	path := fmt.Sprintf("/indexer/partition/%s/file/%s", domain, url.PathEscape(fileID))
 	res, err := callRAG(server, http.MethodDelete, nil, path, echo.MIMEApplicationJSON)
 	if err != nil {
-		return err
+		return retryable(err)
 	}
-	defer res.Body.Close()
-	if res.StatusCode >= 500 {
-		return fmt.Errorf("DELETE status code: %d", res.StatusCode)
-	}
-	return nil
+	res.Body.Close()
+	return statusError("DELETE file", res.StatusCode, http.StatusNotFound)
 }
 
 // needsIndexation reports whether the file must be sent again. isNew tells
 // whether the RAG server knows it at all, which decides between a POST and a PUT.
+// The decision only depends on what the RAG server holds: the index status
+// document (filled by the indexer's callback) is informative for clients but
+// must not drive re-uploads, as a callback that never arrives would otherwise
+// make every run send the file again.
 func needsIndexation(inst *instance.Instance, fileID, md5sum string) (needed, isNew bool, err error) {
 	indexed, known, err := indexedMD5Sum(inst.RAGServer(), inst.Domain, fileID)
 	if err != nil {
@@ -158,12 +584,7 @@ func needsIndexation(inst *instance.Instance, fileID, md5sum string) (needed, is
 	if !known {
 		return true, true, nil
 	}
-	if indexed != md5sum {
-		return true, false, nil
-	}
-	// The RAG server holds this content, but a callback may never have come
-	// back to say so.
-	return !isIndexed(inst, fileID), false, nil
+	return indexed != md5sum, false, nil
 }
 
 // indexedMD5Sum returns the md5sum the RAG server holds for the file. known is
@@ -172,7 +593,7 @@ func indexedMD5Sum(server config.RAGServer, domain, fileID string) (md5sum strin
 	path := fmt.Sprintf("/partition/%s/file/%s", domain, url.PathEscape(fileID))
 	res, err := callRAG(server, http.MethodGet, nil, path, echo.MIMEApplicationJSON)
 	if err != nil {
-		return "", false, err
+		return "", false, retryable(err)
 	}
 	defer res.Body.Close()
 
@@ -188,120 +609,33 @@ func indexedMD5Sum(server config.RAGServer, domain, fileID string) (md5sum strin
 	case http.StatusNotFound:
 		return "", false, nil
 	default:
-		return "", false, fmt.Errorf("GET status code: %d", res.StatusCode)
+		return "", false, statusError("GET file", res.StatusCode)
 	}
 }
 
-func isIndexed(inst *instance.Instance, docID string) bool {
-	var doc IndexStatus
-	if err := couchdb.GetDoc(inst, consts.ChatRAG, docID, &doc); err != nil {
-		return false
+// contentUnavailable classifies a resolveContent failure. Content missing
+// from storage (os.ErrNotExist, opening the file) will not come back: a
+// plain, non-retryable error, so the file is skipped like an indexer
+// refusal instead of failing the batch or the walk. Any other error (a slow
+// filesystem, a transient VFS failure, a note that fails to render) stays
+// retryable.
+func contentUnavailable(fileID string, err error) error {
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("content of file %s is missing: %w", fileID, err)
 	}
-	return doc.Indexed
-}
-
-func upsertToRAG(inst *instance.Instance, doctype string, change couchdb.Change, kb func() *kbContext, logger logger.Logger) error {
-	md5sum := decodeMD5Sum(change.Doc.Get("md5sum"))
-	needed, isNewFile, err := needsIndexation(inst, change.DocID, md5sum)
-	if err != nil {
-		return err
-	}
-
-	dirID, _ := change.Doc.Get("dir_id").(string)
-	if !needed {
-		// The content did not change but the file may have been
-		// moved/renamed: keep the knowledge-base workspaces in sync.
-		reconcileMembership(inst, logger, kb(), change.DocID, dirID)
-		return nil
-	}
-
-	name, content, err := resolveContent(inst, change)
-	if err != nil {
-		return err
-	}
-	defer content.Close()
-
-	// The streaming goroutine below needs the workspace membership, but
-	// kbContext is not safe for concurrent use: resolve it here, on the
-	// indexing loop, before the goroutine starts.
-	workspaceIDsJSON, attachUnknown := resolveWorkspaces(inst, logger, kb(), change.DocID, dirID)
-
-	datetime := ""
-	if metadata, ok := change.Doc.Get("metadata").(map[string]interface{}); ok {
-		datetime, _ = metadata["datetime"].(string)
-	}
-	rev, _ := change.Doc.Get("_rev").(string)
-	meta := map[string]string{
-		"md5sum":   md5sum,
-		"datetime": datetime,
-		"doctype":  doctype,
-		// Echoed back by the indexer on the callback, which is ordered on it.
-		"doc_rev": rev,
-	}
-
-	res, err := uploadToRAG(ragUpload{
-		Server:      inst.RAGServer(),
-		Domain:      inst.Domain,
-		FileID:      change.DocID,
-		Name:        name,
-		DirID:       dirID,
-		MD5Sum:      md5sum,
-		Meta:        meta,
-		Workspaces:  workspaceIDsJSON,
-		CallbackURL: inst.PageURL(IndexStatusPath, nil),
-		IsNew:       isNewFile,
-	}, content)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-	if res.StatusCode >= 500 {
-		return fmt.Errorf("Status code: %d", res.StatusCode)
-	}
-
-	if (!isNewFile || attachUnknown) && res.StatusCode < 300 {
-		// A re-upload may also have moved the file. And for a new file whose
-		// membership could not be resolved before the upload, this is the only
-		// chance to attach it, now that the transient error may have cleared.
-		reconcileMembership(inst, logger, kb(), change.DocID, dirID)
-	}
-	return nil
-}
-
-// resolveWorkspaces returns the knowledge-base workspaces the file belongs to.
-// The boolean tells that they could not be resolved, which is not the same as
-// belonging to none.
-func resolveWorkspaces(inst *instance.Instance, logger logger.Logger, kbc *kbContext, fileID, dirID string) (string, bool) {
-	if kbc.empty() {
-		return "", false
-	}
-	desired, ok := kbc.desiredFor(inst, dirID)
-	if !ok {
-		logger.Warnf("cannot resolve parent path for file %s (dir %s): skipping workspace attach", fileID, dirID)
-		return "", true
-	}
-	if len(desired) == 0 {
-		return "", false
-	}
-	wsJSON, err := json.Marshal(desired)
-	if err != nil {
-		return "", false
-	}
-	return string(wsJSON), false
+	return retryable(err)
 }
 
 // resolveContent returns what to send to the RAG server. A note is sent as the
 // markdown it renders to.
-func resolveContent(inst *instance.Instance, change couchdb.Change) (string, io.ReadCloser, error) {
-	name, _ := change.Doc.Get("name").(string)
-	mime, _ := change.Doc.Get("mime").(string)
+func resolveContent(inst *instance.Instance, f fileInfo) (string, io.ReadCloser, error) {
+	name := f.Name
 
-	if mime == consts.NoteMimeType {
-		metadata, _ := change.Doc.Get("metadata").(map[string]interface{})
-		schema, _ := metadata["schema"].(map[string]interface{})
-		raw, _ := metadata["content"].(map[string]interface{})
+	if f.Mime == consts.NoteMimeType {
+		schema, _ := f.Metadata["schema"].(map[string]interface{})
+		raw, _ := f.Metadata["content"].(map[string]interface{})
 		noteDoc := &note.Document{
-			DocID:      change.DocID,
+			DocID:      f.ID,
 			SchemaSpec: schema,
 			RawContent: raw,
 		}
@@ -314,14 +648,12 @@ func resolveContent(inst *instance.Instance, change couchdb.Change) (string, io.
 		return name, io.NopCloser(bytes.NewReader(md)), nil
 	}
 
-	dirID, _ := change.Doc.Get("dir_id").(string)
-	internalID, _ := change.Doc.Get("internal_vfs_id").(string)
-	f, err := inst.VFS().OpenFile(&vfs.FileDoc{
+	file, err := inst.VFS().OpenFile(&vfs.FileDoc{
 		Type:       consts.FileType,
-		DocID:      change.DocID,
-		DirID:      dirID,
+		DocID:      f.ID,
+		DirID:      f.DirID,
 		DocName:    name,
-		InternalID: internalID,
+		InternalID: f.InternalID,
 	})
 	if err != nil {
 		return "", nil, err
@@ -330,7 +662,7 @@ func resolveContent(inst *instance.Instance, change couchdb.Change) (string, io.
 		// See https://github.com/OpenLLM-France/RAGondin/issues/88
 		name = strings.TrimSuffix(name, consts.DocsExtension) + consts.MarkdownExtension
 	}
-	return name, f, nil
+	return name, file, nil
 }
 
 type ragUpload struct {
@@ -424,40 +756,6 @@ func decodeMD5Sum(v interface{}) string {
 	return hex.EncodeToString(raw)
 }
 
-// getLastSeqNumber returns the last sequence number of the previous
-// indexation for this doctype.
-func getLastSeqNumber(inst *instance.Instance, doctype string) (string, error) {
-	result, err := couchdb.GetLocal(inst, doctype, "rag-index")
-	if couchdb.IsNotFoundError(err) {
-		return "", nil
-	}
-	if err != nil {
-		return "", err
-	}
-	seq, _ := result["last_seq"].(string)
-	return seq, nil
-}
-
-// updateLastSequenceNumber updates the last sequence number for this
-// indexation if it's superior to the number in CouchDB.
-func updateLastSequenceNumber(inst *instance.Instance, doctype, seq string) error {
-	result, err := couchdb.GetLocal(inst, doctype, "rag-index")
-	if err != nil {
-		if !couchdb.IsNotFoundError(err) {
-			return err
-		}
-		result = make(map[string]interface{})
-	} else {
-		if prev, ok := result["last_seq"].(string); ok {
-			if revision.Generation(seq) <= revision.Generation(prev) {
-				return nil
-			}
-		}
-	}
-	result["last_seq"] = seq
-	return couchdb.PutLocal(inst, doctype, "rag-index", result)
-}
-
 // callChangesFeed fetches the last changes from the changes feed
 // http://docs.couchdb.org/en/stable/api/database/changes.html
 func callChangesFeed(inst *instance.Instance, doctype, since string) (*couchdb.ChangesResponse, error) {
@@ -470,19 +768,26 @@ func callChangesFeed(inst *instance.Instance, doctype, since string) (*couchdb.C
 }
 
 // pushJob adds a new job to continue on the pending documents in the changes
-// feed.
-func pushJob(inst *instance.Instance, doctype string) error {
-	msg, err := job.NewMessage(&IndexMessage{
-		Doctype: doctype,
-	})
+// feed, with the same message.
+func pushJob(inst *instance.Instance, msg IndexMessage) error {
+	m, err := job.NewMessage(&msg)
 	if err != nil {
 		return err
 	}
 	_, err = job.System().PushJob(inst, &job.JobRequest{
-		WorkerType: "rag-index",
-		Message:    msg,
+		WorkerType: workerType,
+		Message:    m,
 	})
 	return err
+}
+
+// pushReconcile is a variable so tests can record the pushes.
+var pushReconcile = pushReconcileJob
+
+// pushReconcileJob asks for the initial indexing of a knowledge base folder,
+// in its own job: the walk of a whole subtree does not belong to the batch.
+func pushReconcileJob(inst *instance.Instance, dirID string) error {
+	return pushJob(inst, IndexMessage{Doctype: consts.Files, ReconcileDirID: dirID})
 }
 
 func CleanInstance(inst *instance.Instance) error {

--- a/model/rag/index_http_test.go
+++ b/model/rag/index_http_test.go
@@ -28,7 +28,7 @@ func formFields(t *testing.T, contentType string, body []byte) url.Values {
 }
 
 func TestUploadToRAG(t *testing.T) {
-	upload := func(t *testing.T, up ragUpload) (recordedRequest, string) {
+	upload := func(t *testing.T, up ragUpload) (RecordedRequest, string) {
 		t.Helper()
 		var contentType string
 		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
@@ -41,7 +41,7 @@ func TestUploadToRAG(t *testing.T) {
 		res, err := uploadToRAG(up, strings.NewReader("hello"))
 		require.NoError(t, err)
 		defer res.Body.Close()
-		requests := rec.all()
+		requests := rec.All()
 		require.Len(t, requests, 1)
 		return requests[0], contentType
 	}
@@ -89,7 +89,7 @@ func TestDeleteFromRAGHTTP(t *testing.T) {
 		})
 		require.NoError(t, deleteFromRAGHTTP(server, "alice.example.net", "a1b2c3"))
 
-		requests := rec.all()
+		requests := rec.All()
 		require.Len(t, requests, 1)
 		assert.Equal(t, http.MethodDelete, requests[0].Method)
 		assert.Equal(t, "/indexer/partition/alice.example.net/file/a1b2c3", requests[0].Path)
@@ -120,7 +120,7 @@ func TestIndexedMD5Sum(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, known)
 		assert.Equal(t, "098f6bcd4621d373cade4e832627b4f6", md5sum)
-		assert.Equal(t, "/partition/alice.example.net/file/a1b2c3", rec.all()[0].Path)
+		assert.Equal(t, "/partition/alice.example.net/file/a1b2c3", rec.All()[0].Path)
 	})
 
 	t.Run("an unknown file is reported as such rather than as an error", func(t *testing.T) {

--- a/model/rag/index_integration_test.go
+++ b/model/rag/index_integration_test.go
@@ -1,0 +1,1095 @@
+package rag_test
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/job"
+	"github.com/cozy/cozy-stack/model/rag"
+	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/cozy/cozy-stack/model/vfs/vfsafero"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/tests/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	// The real worker lives in worker/rag, which model/rag cannot import.
+	// Register a no-op worker of the same name so triggers and jobs can be
+	// created in these tests.
+	job.AddWorker(&job.WorkerConfig{
+		WorkerType:  "rag-index",
+		Concurrency: 1,
+		WorkerFunc:  func(*job.TaskContext) error { return nil },
+	})
+}
+
+// ragTest wires a test instance to a fake openRAG.
+type ragTest struct {
+	t    *testing.T
+	inst *instance.Instance
+	fake *rag.FakeOpenRAG
+	// reconciles records the reconcile jobs the worker pushed: the no-op
+	// test worker runs a pushed job at once, so the queue cannot be read.
+	reconciles []string
+}
+
+func newRAGTest(t *testing.T) *ragTest {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("an instance is required for this test: test skipped due to the use of --short flag")
+	}
+	config.UseTestFile(t)
+	testutils.NeedCouchdb(t)
+	setup := testutils.NewSetup(t, t.Name())
+	inst := setup.GetTestInstance()
+	fake := rag.NewFakeOpenRAG(t)
+	previous := config.GetConfig().RAGServers
+	config.GetConfig().RAGServers = map[string]config.RAGServer{config.DefaultInstanceContext: fake.Server}
+	t.Cleanup(func() { config.GetConfig().RAGServers = previous })
+	r := &ragTest{t: t, inst: inst, fake: fake}
+	t.Cleanup(rag.SetReconcilePushForTest(func(_ *instance.Instance, dirID string) error {
+		r.reconciles = append(r.reconciles, dirID)
+		return nil
+	}))
+	return r
+}
+
+func (r *ragTest) mkdir(path string) *vfs.DirDoc {
+	r.t.Helper()
+	dir, err := vfs.MkdirAll(r.inst.VFS(), path)
+	require.NoError(r.t, err)
+	return dir
+}
+
+func (r *ragTest) writeFile(path, content string) *vfs.FileDoc {
+	r.t.Helper()
+	f, err := vfs.Create(r.inst.VFS(), path)
+	require.NoError(r.t, err)
+	_, err = f.Write([]byte(content))
+	require.NoError(r.t, err)
+	require.NoError(r.t, f.Close())
+	doc, err := r.inst.VFS().FileByPath(path)
+	require.NoError(r.t, err)
+	return doc
+}
+
+// rewriteFile replaces the content of an existing file, the way a re-upload
+// from the client does: a new revision, a new md5sum, the same doc id.
+func (r *ragTest) rewriteFile(path, content string) *vfs.FileDoc {
+	r.t.Helper()
+	f, err := vfs.OpenFile(r.inst.VFS(), path, os.O_WRONLY, 0)
+	require.NoError(r.t, err)
+	_, err = f.Write([]byte(content))
+	require.NoError(r.t, err)
+	require.NoError(r.t, f.Close())
+	doc, err := r.inst.VFS().FileByPath(path)
+	require.NoError(r.t, err)
+	return doc
+}
+
+func (r *ragTest) index() error {
+	return rag.Index(r.inst, rag.TestingLogger(), rag.IndexMessage{Doctype: consts.Files})
+}
+
+// drainReconcileJobs returns the reconcile jobs pushed so far, and forgets
+// them.
+func (r *ragTest) drainReconcileJobs() []string {
+	pushed := r.reconciles
+	r.reconciles = nil
+	return pushed
+}
+
+// runUntilSettled runs the job, then any reconcile job it pushed, until no
+// job is left: the no-op test worker does not execute pushed jobs.
+func (r *ragTest) runUntilSettled() {
+	r.t.Helper()
+	require.NoError(r.t, r.index())
+	for _, dirID := range r.drainReconcileJobs() {
+		require.NoError(r.t, rag.Index(r.inst, rag.TestingLogger(), rag.IndexMessage{Doctype: consts.Files, ReconcileDirID: dirID}))
+	}
+	assert.Empty(r.t, r.reconciles, "a reconcile job must not push reconcile jobs")
+}
+
+// checkpoint reads the checkpoint as the worker stores it, in a CouchDB
+// local document. Both values are zero when there is none.
+func (r *ragTest) checkpoint() (lastSeq string, retries int) {
+	r.t.Helper()
+	doc, err := couchdb.GetLocal(r.inst, consts.Files, "rag-index")
+	if couchdb.IsNotFoundError(err) {
+		return "", 0
+	}
+	require.NoError(r.t, err)
+	lastSeq, _ = doc["last_seq"].(string)
+	if n, ok := doc["retries"].(float64); ok {
+		retries = int(n)
+	}
+	return lastSeq, retries
+}
+
+func (r *ragTest) seedCheckpoint(lastSeq string, retries int) {
+	r.t.Helper()
+	doc := map[string]interface{}{"last_seq": lastSeq, "retries": retries}
+	require.NoError(r.t, couchdb.PutLocal(r.inst, consts.Files, "rag-index", doc))
+}
+
+// addAssistant creates an assistant whose knowledge base is the folder.
+func (r *ragTest) addAssistant(name, dirID string) string {
+	r.t.Helper()
+	doc := couchdb.JSONDoc{Type: consts.ChatAssistants, M: map[string]interface{}{
+		"name": name,
+		"knowledgeBase": []map[string]interface{}{
+			{"doctype": consts.Files, "dirId": dirID},
+		},
+	}}
+	require.NoError(r.t, couchdb.CreateDoc(r.inst, &doc))
+	return doc.ID()
+}
+
+// setAssistantFolder replaces the knowledge base folder of an assistant
+// (dirID empty: no folder at all).
+func (r *ragTest) setAssistantFolder(assistantID, dirID string) {
+	r.t.Helper()
+	var doc couchdb.JSONDoc
+	require.NoError(r.t, couchdb.GetDoc(r.inst, consts.ChatAssistants, assistantID, &doc))
+	doc.Type = consts.ChatAssistants
+	if dirID == "" {
+		doc.M["knowledgeBase"] = []map[string]interface{}{}
+	} else {
+		doc.M["knowledgeBase"] = []map[string]interface{}{{"doctype": consts.Files, "dirId": dirID}}
+	}
+	require.NoError(r.t, couchdb.UpdateDoc(r.inst, &doc))
+}
+
+func (r *ragTest) deleteAssistant(assistantID string) {
+	r.t.Helper()
+	var doc couchdb.JSONDoc
+	require.NoError(r.t, couchdb.GetDoc(r.inst, consts.ChatAssistants, assistantID, &doc))
+	doc.Type = consts.ChatAssistants
+	require.NoError(r.t, couchdb.DeleteDoc(r.inst, &doc))
+}
+
+func (r *ragTest) uploads(doc *vfs.FileDoc) int {
+	return r.fake.Rec.Count(http.MethodPost, "/indexer/partition/"+r.inst.Domain+"/file/"+doc.DocID) +
+		r.fake.Rec.Count(http.MethodPut, "/indexer/partition/"+r.inst.Domain+"/file/"+doc.DocID)
+}
+
+// workspaceIDs is the sorted list openRAG receives as workspace_ids: the
+// folder ids are sorted, then mapped to workspace ids.
+func workspaceIDs(dirIDs ...string) []string {
+	slices.Sort(dirIDs)
+	ids := make([]string, len(dirIDs))
+	for i, dirID := range dirIDs {
+		if dirID == consts.RootDirID {
+			ids[i] = rag.RootWorkspaceID
+		} else {
+			ids[i] = dirID
+		}
+	}
+	return ids
+}
+
+func TestIndexAssistantFolder(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	sub := r.mkdir("/KB/sub")
+	r.mkdir("/Other")
+	inKB := r.writeFile("/KB/a.txt", "alpha")
+	inSub := r.writeFile("/KB/sub/b.txt", "beta")
+	outside := r.writeFile("/Other/c.txt", "gamma")
+	r.addAssistant("KB assistant", kb.DocID)
+
+	r.runUntilSettled()
+
+	assert.True(t, r.fake.HasWorkspace(kb.DocID), "the workspace of the knowledge base folder is created")
+	assert.False(t, r.fake.HasWorkspace(sub.DocID))
+	assert.ElementsMatch(t, []string{inKB.DocID, inSub.DocID}, r.fake.FileIDs())
+	ff, _ := r.fake.File(inKB.DocID)
+	assert.Equal(t, []string{kb.DocID}, ff.Workspaces)
+	assert.Equal(t, hex.EncodeToString(inKB.MD5Sum), ff.MD5)
+	_, ok := r.fake.File(outside.DocID)
+	assert.False(t, ok, "out-of-scope files never reach openRAG")
+
+	lastSeq, _ := r.checkpoint()
+	assert.NotEmpty(t, lastSeq)
+
+	// Second run: nothing changed, no upload.
+	uploads := r.uploads(inKB)
+	r.runUntilSettled()
+	assert.Equal(t, uploads, r.uploads(inKB))
+}
+
+func TestIndexRootAssistant(t *testing.T) {
+	r := newRAGTest(t)
+	r.mkdir("/Sub")
+	top := r.writeFile("/top.txt", "top")
+	inSub := r.writeFile("/Sub/s.txt", "sub")
+	r.addAssistant("Everything", consts.RootDirID)
+
+	r.runUntilSettled()
+
+	assert.True(t, r.fake.HasWorkspace(rag.RootWorkspaceID), "the root folder id is not a valid workspace id")
+	assert.False(t, r.fake.HasWorkspace(consts.RootDirID))
+	assert.ElementsMatch(t, []string{top.DocID, inSub.DocID}, r.fake.FileIDs())
+	ff, _ := r.fake.File(inSub.DocID)
+	assert.Equal(t, []string{rag.RootWorkspaceID}, ff.Workspaces)
+
+	var body string
+	for _, req := range r.fake.Rec.All() {
+		if req.Method == http.MethodPost && req.Path == "/partition/"+r.inst.Domain+"/workspaces" {
+			body = string(req.Body)
+		}
+	}
+	assert.Contains(t, body, `"display_name":"Drive"`)
+	assert.Contains(t, body, `"workspace_id":"`+rag.RootWorkspaceID+`"`)
+}
+
+// TestIndexRootAndFolderAssistants covers a file claimed by both the root
+// assistant and a folder one: the upload carries both workspace ids.
+func TestIndexRootAndFolderAssistants(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	inKB := r.writeFile("/KB/a.txt", "alpha")
+	outside := r.writeFile("/top.txt", "top")
+	r.addAssistant("Everything", consts.RootDirID)
+	r.addAssistant("KB assistant", kb.DocID)
+
+	r.runUntilSettled()
+
+	assert.True(t, r.fake.HasWorkspace(rag.RootWorkspaceID))
+	assert.True(t, r.fake.HasWorkspace(kb.DocID))
+	ff, ok := r.fake.File(inKB.DocID)
+	require.True(t, ok)
+	// The folder ids are sorted, then mapped: a hexadecimal id sorts before
+	// the root workspace id.
+	assert.Equal(t, []string{kb.DocID, rag.RootWorkspaceID}, ff.Workspaces)
+	assert.Equal(t, workspaceIDs(kb.DocID, consts.RootDirID), ff.Workspaces)
+	assert.Equal(t, 1, r.uploads(inKB), "uploaded once, with both memberships")
+	ff, ok = r.fake.File(outside.DocID)
+	require.True(t, ok)
+	assert.Equal(t, []string{rag.RootWorkspaceID}, ff.Workspaces)
+}
+
+// TestIndexSharedDrivesAssistant covers the other well-known folder ids: a
+// user can pick "Shared drives" as a knowledge base, and its id has dots
+// too, so openRAG would refuse it as a workspace id.
+func TestIndexSharedDrivesAssistant(t *testing.T) {
+	r := newRAGTest(t)
+	drives, err := r.inst.EnsureSharedDrivesDir()
+	require.NoError(t, err)
+	require.Equal(t, consts.SharedDrivesDirID, drives.DocID)
+	doc := r.writeFile(drives.Fullpath+"/d.txt", "drive")
+	r.addAssistant("Shared drives", consts.SharedDrivesDirID)
+
+	r.runUntilSettled()
+
+	assert.True(t, r.fake.HasWorkspace("io-cozy-files-shared-drives-dir"))
+	assert.False(t, r.fake.HasWorkspace(consts.SharedDrivesDirID))
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok)
+	assert.Equal(t, []string{"io-cozy-files-shared-drives-dir"}, ff.Workspaces)
+}
+
+// TestIndexRootAssistantDeleted checks that the whole-Drive workspace is
+// removed, and its files with it, when the last root assistant is gone.
+func TestIndexRootAssistantDeleted(t *testing.T) {
+	r := newRAGTest(t)
+	doc := r.writeFile("/top.txt", "top")
+	assistant := r.addAssistant("Everything", consts.RootDirID)
+	r.runUntilSettled()
+	require.True(t, r.fake.HasWorkspace(rag.RootWorkspaceID))
+
+	r.deleteAssistant(assistant)
+	r.runUntilSettled()
+
+	assert.False(t, r.fake.HasWorkspace(rag.RootWorkspaceID))
+	_, ok := r.fake.File(doc.DocID)
+	assert.False(t, ok, "its files were detached and deleted")
+}
+
+// TestIndexStaleRootWorkspaceRemoved covers the removal side of the mapping:
+// a leftover whole-Drive workspace, with no root assistant any more, must be
+// resolved back to the root folder and removed.
+func TestIndexStaleRootWorkspaceRemoved(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	inKB := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.fake.AddWorkspace(rag.RootWorkspaceID)
+	r.fake.AddFile(inKB.DocID, "x", rag.RootWorkspaceID)
+
+	r.runUntilSettled()
+
+	assert.False(t, r.fake.HasWorkspace(rag.RootWorkspaceID), "no assistant indexes the whole Drive any more")
+	assert.True(t, r.fake.HasWorkspace(kb.DocID))
+	ff, ok := r.fake.File(inKB.DocID)
+	require.True(t, ok, "the file is still claimed by /KB")
+	assert.Equal(t, []string{kb.DocID}, ff.Workspaces)
+}
+
+// TestIndexNoReconcileJobWhenWorkspaceCreationFails is the ordering rule:
+// nothing is walked into a workspace that does not exist. The job itself
+// succeeds, and the next run retries the creation.
+func TestIndexNoReconcileJobWhenWorkspaceCreationFails(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+
+	r.fake.Fail = func(method, path string) int {
+		if method == http.MethodPost && path == "/partition/"+r.inst.Domain+"/workspaces" {
+			return http.StatusInternalServerError
+		}
+		return 0
+	}
+	require.NoError(t, r.index(), "a creation failure is logged, not raised")
+	assert.False(t, r.fake.HasWorkspace(kb.DocID))
+	assert.Empty(t, r.reconciles, "no reconcile job without a workspace to index into")
+
+	r.fake.Fail = nil
+	r.runUntilSettled()
+	assert.True(t, r.fake.HasWorkspace(kb.DocID), "the next run retries the creation")
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok, "and pushes the reconcile job that indexes the subtree")
+	assert.Equal(t, []string{kb.DocID}, ff.Workspaces)
+}
+
+// TestIndexWorkspaceRolledBackWhenPushFails is the other half: a workspace
+// whose reconcile job could not be pushed is deleted again. Left there, it
+// would claim the folder is indexed (checkWorkspace succeeds) while nothing
+// walks its subtree any more.
+func TestIndexWorkspaceRolledBackWhenPushFails(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+
+	restore := rag.SetReconcilePushForTest(func(*instance.Instance, string) error {
+		return errors.New("the job queue is unreachable")
+	})
+	require.NoError(t, r.index(), "a push failure is logged, not raised")
+	restore()
+	assert.Equal(t, 1, r.fake.Rec.Count(http.MethodPost, "/partition/"+r.inst.Domain+"/workspaces"), "the workspace was created first")
+	assert.Equal(t, 1, r.fake.Rec.Count(http.MethodDelete, "/partition/"+r.inst.Domain+"/workspaces/"+kb.DocID), "then rolled back")
+	assert.False(t, r.fake.HasWorkspace(kb.DocID))
+
+	r.runUntilSettled()
+	assert.True(t, r.fake.HasWorkspace(kb.DocID), "the next run creates it and pushes the job")
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok)
+	assert.Equal(t, []string{kb.DocID}, ff.Workspaces)
+}
+
+func TestIndexNestedAssistants(t *testing.T) {
+	r := newRAGTest(t)
+	outer := r.mkdir("/Outer")
+	inner := r.mkdir("/Outer/Inner")
+	doc := r.writeFile("/Outer/Inner/x.txt", "x")
+	r.addAssistant("Outer", outer.DocID)
+	r.addAssistant("Inner", inner.DocID)
+
+	r.runUntilSettled()
+
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok)
+	assert.Equal(t, workspaceIDs(outer.DocID, inner.DocID), ff.Workspaces)
+	assert.Equal(t, 1, r.uploads(doc), "uploaded once, with both memberships")
+}
+
+func TestIndexNoAssistant(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	// Leftovers of a knowledge base that is not one any more.
+	r.fake.AddWorkspace(kb.DocID)
+	r.fake.AddFile(doc.DocID, hex.EncodeToString(doc.MD5Sum), kb.DocID)
+
+	r.runUntilSettled()
+
+	assert.False(t, r.fake.HasWorkspace(kb.DocID), "a workspace without assistant is removed")
+	assert.Empty(t, r.fake.FileIDs(), "its files belong to no knowledge base any more")
+}
+
+func TestIndexAssistantCreatedOnFullFolder(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	r.mkdir("/KB/sub")
+	a := r.writeFile("/KB/a.txt", "alpha")
+	b := r.writeFile("/KB/sub/b.txt", "beta")
+
+	// A first run without any assistant: the checkpoint moves past the files.
+	r.runUntilSettled()
+	require.Empty(t, r.fake.FileIDs())
+
+	// Creating the assistant changes no file document: the subtree can only
+	// be indexed by the reconcile job the workspace diff pushes.
+	r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+
+	assert.True(t, r.fake.HasWorkspace(kb.DocID))
+	assert.ElementsMatch(t, []string{a.DocID, b.DocID}, r.fake.FileIDs())
+	ff, _ := r.fake.File(b.DocID)
+	assert.Equal(t, []string{kb.DocID}, ff.Workspaces)
+}
+
+func TestIndexAssistantFolderChanged(t *testing.T) {
+	r := newRAGTest(t)
+	dirA := r.mkdir("/A")
+	dirB := r.mkdir("/B")
+	inA := r.writeFile("/A/a.txt", "alpha")
+	inB := r.writeFile("/B/b.txt", "beta")
+	assistant := r.addAssistant("KB assistant", dirA.DocID)
+	r.runUntilSettled()
+	require.Equal(t, []string{inA.DocID}, r.fake.FileIDs())
+
+	r.setAssistantFolder(assistant, dirB.DocID)
+	r.runUntilSettled()
+
+	assert.False(t, r.fake.HasWorkspace(dirA.DocID), "the workspace of the old folder is gone")
+	_, ok := r.fake.File(inA.DocID)
+	assert.False(t, ok, "its files were detached and deleted")
+	assert.True(t, r.fake.HasWorkspace(dirB.DocID))
+	ff, ok := r.fake.File(inB.DocID)
+	require.True(t, ok, "the new folder is indexed")
+	assert.Equal(t, []string{dirB.DocID}, ff.Workspaces)
+}
+
+func TestIndexAssistantDeleted(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	assistant := r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+	require.True(t, r.fake.HasWorkspace(kb.DocID))
+
+	r.deleteAssistant(assistant)
+	r.runUntilSettled()
+
+	assert.False(t, r.fake.HasWorkspace(kb.DocID))
+	_, ok := r.fake.File(doc.DocID)
+	assert.False(t, ok)
+	var status rag.IndexStatus
+	err := couchdb.GetDoc(r.inst, consts.ChatRAG, doc.DocID, &status)
+	assert.True(t, couchdb.IsNotFoundError(err) || couchdb.IsNoDatabaseError(err), "its index status is gone too")
+}
+
+func TestIndexSharedFolder(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	first := r.addAssistant("First", kb.DocID)
+	r.addAssistant("Second", kb.DocID)
+	r.runUntilSettled()
+	require.True(t, r.fake.HasWorkspace(kb.DocID))
+
+	r.deleteAssistant(first)
+	r.runUntilSettled()
+
+	assert.True(t, r.fake.HasWorkspace(kb.DocID), "the second assistant still uses the folder")
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok)
+	assert.Equal(t, []string{kb.DocID}, ff.Workspaces)
+}
+
+func TestIndexMoveOutOfScope(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	other := r.mkdir("/Other")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+	_, ok := r.fake.File(doc.DocID)
+	require.True(t, ok)
+
+	_, err := vfs.ModifyFileMetadata(r.inst.VFS(), doc, &vfs.DocPatch{DirID: &other.DocID})
+	require.NoError(t, err)
+	r.runUntilSettled()
+
+	_, ok = r.fake.File(doc.DocID)
+	assert.False(t, ok, "in no knowledge base any more: deleted")
+	var status rag.IndexStatus
+	err = couchdb.GetDoc(r.inst, consts.ChatRAG, doc.DocID, &status)
+	assert.True(t, couchdb.IsNotFoundError(err), "its index status is gone too")
+}
+
+func TestIndexMoveBetweenFolders(t *testing.T) {
+	r := newRAGTest(t)
+	dirA := r.mkdir("/A")
+	dirB := r.mkdir("/B")
+	doc := r.writeFile("/A/a.txt", "alpha")
+	r.addAssistant("A", dirA.DocID)
+	r.addAssistant("B", dirB.DocID)
+	r.runUntilSettled()
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok)
+	require.Equal(t, []string{dirA.DocID}, ff.Workspaces)
+
+	_, err := vfs.ModifyFileMetadata(r.inst.VFS(), doc, &vfs.DocPatch{DirID: &dirB.DocID})
+	require.NoError(t, err)
+	r.runUntilSettled()
+
+	ff, ok = r.fake.File(doc.DocID)
+	require.True(t, ok, "the file stays on openRAG: no delete/re-upload cycle")
+	assert.Equal(t, []string{dirB.DocID}, ff.Workspaces)
+	assert.Equal(t, 1, r.uploads(doc), "the memberships were diffed, not the content re-sent")
+}
+
+func TestIndexNewFileOutOfScopeSkipsOpenRAG(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	r.mkdir("/Other")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+
+	doc := r.writeFile("/Other/c.txt", "gamma")
+	r.runUntilSettled()
+
+	assert.Equal(t, "1-", doc.DocRev[:2])
+	assert.Equal(t, 0, r.uploads(doc))
+	assert.Equal(t, 0, r.fake.Rec.Count(http.MethodGet, "/partition/"+r.inst.Domain+"/files/"+doc.DocID+"/workspaces"), "a rev 1- file out of scope costs no openRAG call")
+}
+
+func TestIndexSubtreeMove(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	moving := r.mkdir("/Moving")
+	doc := r.writeFile("/Moving/d.txt", "delta")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+	_, ok := r.fake.File(doc.DocID)
+	require.False(t, ok)
+
+	// Drag /Moving into /KB: only the dir doc changes.
+	_, err := vfs.ModifyDirMetadata(r.inst.VFS(), moving, &vfs.DocPatch{DirID: &kb.DocID})
+	require.NoError(t, err)
+	r.runUntilSettled()
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok, "files of a subtree dragged into a knowledge base are indexed")
+	assert.Equal(t, []string{kb.DocID}, ff.Workspaces)
+
+	// Drag it back out.
+	moved, err := r.inst.VFS().DirByID(moving.DocID)
+	require.NoError(t, err)
+	root := consts.RootDirID
+	_, err = vfs.ModifyDirMetadata(r.inst.VFS(), moved, &vfs.DocPatch{DirID: &root})
+	require.NoError(t, err)
+	r.runUntilSettled()
+	_, ok = r.fake.File(doc.DocID)
+	assert.False(t, ok, "files of a subtree dragged out are deleted")
+}
+
+func TestIndexTrashAndRestoreKBFolder(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+
+	trashed, err := vfs.TrashDir(r.inst.VFS(), kb)
+	require.NoError(t, err)
+	r.runUntilSettled()
+	_, ok := r.fake.File(doc.DocID)
+	assert.False(t, ok, "a trashed knowledge base folder contains nothing")
+	assert.True(t, r.fake.HasWorkspace(kb.DocID), "the workspace is kept while an assistant references it")
+
+	_, err = vfs.RestoreDir(r.inst.VFS(), trashed)
+	require.NoError(t, err)
+	r.runUntilSettled()
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok, "restored: indexed again")
+	assert.Equal(t, []string{kb.DocID}, ff.Workspaces)
+}
+
+func TestIndexRenameKBFolder(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok)
+	require.Equal(t, []string{kb.DocID}, ff.Workspaces)
+	uploads := r.uploads(doc)
+
+	// The scope follows the folder by id, not by path.
+	name := "Knowledge"
+	_, err := vfs.ModifyDirMetadata(r.inst.VFS(), kb, &vfs.DocPatch{Name: &name})
+	require.NoError(t, err)
+	r.runUntilSettled()
+
+	ff, ok = r.fake.File(doc.DocID)
+	require.True(t, ok, "a renamed knowledge base folder still claims its files")
+	assert.Equal(t, []string{kb.DocID}, ff.Workspaces)
+	assert.Equal(t, uploads, r.uploads(doc), "a rename is not a new content")
+}
+
+func TestIndexReuploadKeepsMemberships(t *testing.T) {
+	r := newRAGTest(t)
+	outer := r.mkdir("/Outer")
+	inner := r.mkdir("/Outer/Inner")
+	doc := r.writeFile("/Outer/Inner/x.txt", "x")
+	r.addAssistant("Outer", outer.DocID)
+	r.addAssistant("Inner", inner.DocID)
+	r.runUntilSettled()
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok)
+	require.Equal(t, workspaceIDs(outer.DocID, inner.DocID), ff.Workspaces)
+
+	// A new content: openRAG replaces the membership list on every upload,
+	// so the upload has to carry every desired workspace.
+	r.rewriteFile("/Outer/Inner/x.txt", "x and more")
+	r.runUntilSettled()
+
+	assert.Equal(t, 2, r.uploads(doc), "the new content was sent")
+	ff, ok = r.fake.File(doc.DocID)
+	require.True(t, ok)
+	assert.Equal(t, workspaceIDs(outer.DocID, inner.DocID), ff.Workspaces)
+}
+
+func TestIndexDeletedFileIsRemoved(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+
+	_, err := vfs.TrashFile(r.inst.VFS(), doc)
+	require.NoError(t, err)
+	r.runUntilSettled()
+	_, ok := r.fake.File(doc.DocID)
+	assert.False(t, ok)
+}
+
+func TestIndexNotSupportedClassStatus(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	img := r.writeFile("/KB/pic.jpg", "not really a jpeg")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+
+	assert.Equal(t, 0, r.uploads(img), "images are not indexed without the flag")
+	var status rag.IndexStatus
+	require.NoError(t, couchdb.GetDoc(r.inst, consts.ChatRAG, img.DocID, &status))
+	assert.Equal(t, rag.StatusNotSupported, status.Status)
+}
+
+func TestIndexKeepsCheckpointOnRetryableError(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+
+	r.fake.Fail = func(method, path string) int {
+		if method == http.MethodPost && path == "/indexer/partition/"+r.inst.Domain+"/file/"+doc.DocID {
+			return 503
+		}
+		return 0
+	}
+	err := r.index()
+	require.Error(t, err)
+	lastSeq, retries := r.checkpoint()
+	assert.Empty(t, lastSeq, "checkpoint not advanced")
+	assert.Equal(t, 1, retries, "the retryable error counts as an attempt")
+
+	r.fake.Fail = nil
+	require.NoError(t, r.index())
+	_, ok := r.fake.File(doc.DocID)
+	assert.True(t, ok)
+	lastSeq, retries = r.checkpoint()
+	assert.NotEmpty(t, lastSeq)
+	assert.Equal(t, 0, retries)
+}
+
+func TestIndexGivesUpAfterMaxRetries(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.seedCheckpoint("", rag.MaxBatchRetries)
+
+	r.fake.Fail = func(method, path string) int {
+		if method == http.MethodPost && path == "/indexer/partition/"+r.inst.Domain+"/file/"+doc.DocID {
+			return 503
+		}
+		return 0
+	}
+	err := r.index()
+	require.Error(t, err)
+	lastSeq, retries := r.checkpoint()
+	assert.NotEmpty(t, lastSeq, "past the cap the batch advances anyway")
+	assert.Equal(t, 0, retries)
+}
+
+func TestIndexNonRetryableErrorIsSkipped(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	bad := r.writeFile("/KB/bad.txt", "bad")
+	good := r.writeFile("/KB/good.txt", "good")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.fake.Fail = func(method, path string) int {
+		if method == http.MethodPost && path == "/indexer/partition/"+r.inst.Domain+"/file/"+bad.DocID {
+			return 415
+		}
+		return 0
+	}
+
+	// A 4xx is logged and skipped: the job itself succeeds, replaying it
+	// would only hit the same 4xx again.
+	require.NoError(t, r.index())
+	_, ok := r.fake.File(good.DocID)
+	assert.True(t, ok, "the batch continued past the 4xx")
+	lastSeq, _ := r.checkpoint()
+	assert.NotEmpty(t, lastSeq, "4xx does not hold the checkpoint")
+}
+
+// TestReconcileJobStaysOnItsOwnFolder covers the race where a knowledge base
+// folder appears while a reconcile job is queued: the reconcile job must not
+// create the other folder's workspace. It pushes no reconcile job, and the
+// files of that folder did not change, so the feed job that follows would
+// see nothing to do while the workspace claims the folder is indexed.
+func TestReconcileJobStaysOnItsOwnFolder(t *testing.T) {
+	r := newRAGTest(t)
+	dirA := r.mkdir("/A")
+	dirB := r.mkdir("/B")
+	inA := r.writeFile("/A/a.txt", "alpha")
+	inB := r.writeFile("/B/b.txt", "beta")
+	r.addAssistant("A", dirA.DocID)
+	r.addAssistant("B", dirB.DocID)
+
+	// The reconcile job of /A, running before any feed job.
+	require.NoError(t, rag.Index(r.inst, rag.TestingLogger(), rag.IndexMessage{
+		Doctype: consts.Files, ReconcileDirID: dirA.DocID,
+	}))
+
+	assert.True(t, r.fake.HasWorkspace(dirA.DocID), "its own workspace is created")
+	assert.False(t, r.fake.HasWorkspace(dirB.DocID), "another folder's workspace is left to a feed job")
+	assert.Empty(t, r.reconciles, "a reconcile job pushes no reconcile job")
+	ff, ok := r.fake.File(inA.DocID)
+	require.True(t, ok, "its own subtree is indexed")
+	assert.Equal(t, []string{dirA.DocID}, ff.Workspaces)
+	_, ok = r.fake.File(inB.DocID)
+	assert.False(t, ok, "the other folder is not indexed by this job")
+
+	// The feed job that follows creates /B's workspace and reconciles it.
+	r.runUntilSettled()
+
+	assert.True(t, r.fake.HasWorkspace(dirB.DocID))
+	ff, ok = r.fake.File(inB.DocID)
+	require.True(t, ok, "the feed job pushed the reconcile job of /B")
+	assert.Equal(t, []string{dirB.DocID}, ff.Workspaces)
+}
+
+// TestReconcileJobDoesNotRemoveWorkspaces checks the other half of the
+// invariant: removals are the feed job's business, a reconcile job is
+// bounded to its own folder.
+func TestReconcileJobDoesNotRemoveWorkspaces(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+	// A workspace of a folder that is in no knowledge base any more.
+	r.fake.AddWorkspace("stale")
+	r.fake.AddFile("ghost", "x", "stale")
+
+	require.NoError(t, rag.Index(r.inst, rag.TestingLogger(), rag.IndexMessage{
+		Doctype: consts.Files, ReconcileDirID: kb.DocID,
+	}))
+
+	assert.True(t, r.fake.HasWorkspace("stale"), "a reconcile job removes no workspace")
+	_, ok := r.fake.File("ghost")
+	assert.True(t, ok, "and detaches nothing")
+
+	r.runUntilSettled()
+	assert.False(t, r.fake.HasWorkspace("stale"), "the feed job removes it")
+}
+
+// TestReconcileSkipsFileRefusedByIndexer is the resilience rule of a walk:
+// one file the indexer refuses for good must not fail the whole reconcile
+// job, or every retry replays the same walk to the same refusal.
+func TestReconcileSkipsFileRefusedByIndexer(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	bad := r.writeFile("/KB/bad.txt", "bad")
+	good := r.writeFile("/KB/good.txt", "good")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.fake.Fail = func(method, path string) int {
+		if method == http.MethodPost && path == "/indexer/partition/"+r.inst.Domain+"/file/"+bad.DocID {
+			return http.StatusUnsupportedMediaType
+		}
+		return 0
+	}
+
+	require.NoError(t, rag.Index(r.inst, rag.TestingLogger(), rag.IndexMessage{
+		Doctype: consts.Files, ReconcileDirID: kb.DocID,
+	}), "a 4xx on one file does not fail the job")
+
+	_, ok := r.fake.File(good.DocID)
+	assert.True(t, ok, "the walk continued past the refused file")
+	_, ok = r.fake.File(bad.DocID)
+	assert.False(t, ok, "the refused file is not indexed")
+
+	// The workspace exists now, so no reconcile job is pushed any more: the
+	// refused file stays unindexed until it changes, or until an operator
+	// runs `cozy-stack rag reconcile --dir-id`.
+	require.NoError(t, r.index())
+	assert.Empty(t, r.reconciles, "the folder is not walked again")
+	_, ok = r.fake.File(bad.DocID)
+	assert.False(t, ok)
+}
+
+// TestReconcileRetryableFileErrorFailsTheJob is the other half of the rule:
+// a transient failure on a file must fail the job, so that the worker walks
+// the folder again. The walk still covers the rest of the subtree.
+func TestReconcileRetryableFileErrorFailsTheJob(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	other := r.writeFile("/KB/b.txt", "beta")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.fake.Fail = func(method, path string) int {
+		if method == http.MethodPost && path == "/indexer/partition/"+r.inst.Domain+"/file/"+doc.DocID {
+			return http.StatusInternalServerError
+		}
+		return 0
+	}
+
+	err := rag.Index(r.inst, rag.TestingLogger(), rag.IndexMessage{
+		Doctype: consts.Files, ReconcileDirID: kb.DocID,
+	})
+
+	require.Error(t, err)
+	assert.True(t, rag.IsRetryableForTest(err), "a 5xx on one file asks for another walk")
+	_, ok := r.fake.File(other.DocID)
+	assert.True(t, ok, "the walk went on past the transient failure")
+	_, ok = r.fake.File(doc.DocID)
+	assert.False(t, ok)
+}
+
+// TestIndexPendingFileIsReuploadedWithPut covers the asynchronous indexing of
+// openRAG: between the POST and the end of the indexing task, the file is
+// unknown to a GET but a second POST conflicts. The upload must fall back to
+// a PUT instead of failing the job.
+func TestIndexPendingFileIsReuploadedWithPut(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+	// Its indexing task is still running on openRAG: GET 404, POST 409.
+	r.fake.AddPendingFile(doc.DocID)
+
+	r.runUntilSettled()
+
+	path := "/indexer/partition/" + r.inst.Domain + "/file/" + doc.DocID
+	assert.Equal(t, 1, r.fake.Rec.Count(http.MethodPost, path), "one POST, refused with a 409")
+	assert.Equal(t, 1, r.fake.Rec.Count(http.MethodPut, path), "then one PUT, accepted")
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok)
+	assert.Equal(t, hex.EncodeToString(doc.MD5Sum), ff.MD5, "the content was sent again")
+	assert.Equal(t, []string{kb.DocID}, ff.Workspaces, "the memberships survived the PUT")
+}
+
+// TestIndexDuplicateContentIsSkipped covers openRAG's content deduplication:
+// a partition holds one document per distinct content, so a file whose
+// content is already indexed under another id is refused with a 409
+// DOCUMENT_CONTENT_EXISTS. It is skipped for good — no PUT fallback, no
+// failure of the batch.
+func TestIndexDuplicateContentIsSkipped(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	r.addAssistant("KB assistant", kb.DocID)
+	// The workspace now exists: the files below are indexed by the batch
+	// alone, without a reconcile job walking them a second time.
+	r.runUntilSettled()
+
+	// Two batches, so that the file openRAG holds the content of is the
+	// first one whatever order the changes feed gives them in.
+	first := r.writeFile("/KB/a.txt", "the very same content")
+	require.NoError(t, r.index())
+	require.Equal(t, []string{first.DocID}, r.fake.FileIDs())
+
+	dup := r.writeFile("/KB/b.txt", "the very same content")
+	require.NoError(t, r.index(), "a content duplicate does not fail the batch")
+	assert.Empty(t, r.reconciles)
+
+	assert.Equal(t, []string{first.DocID}, r.fake.FileIDs(), "the duplicate is not indexed")
+	path := "/indexer/partition/" + r.inst.Domain + "/file/" + dup.DocID
+	assert.Equal(t, 1, r.fake.Rec.Count(http.MethodPost, path), "one POST, refused with a 409")
+	assert.Equal(t, 0, r.fake.Rec.Count(http.MethodPut, path), "and no PUT: a PUT would answer 404")
+
+	lastSeq, retries := r.checkpoint()
+	assert.NotEmpty(t, lastSeq, "the checkpoint advances")
+	assert.Zero(t, retries)
+}
+
+// TestReconcileSkipsDuplicateContent is the same rule on the walk of a
+// knowledge base folder: the duplicate is skipped, the other files are
+// indexed and the job succeeds.
+func TestReconcileSkipsDuplicateContent(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	// The walk visits the children in the order of the dir-children index
+	// (dir_id, _id), which says nothing about their names or their creation
+	// order: which of the two copies openRAG keeps is not for this test to
+	// decide, only that exactly one of them is kept.
+	a := r.writeFile("/KB/a.txt", "the very same content")
+	b := r.writeFile("/KB/b.txt", "the very same content")
+	other := r.writeFile("/KB/c.txt", "something else")
+	r.addAssistant("KB assistant", kb.DocID)
+
+	err := rag.Index(r.inst, rag.TestingLogger(), rag.IndexMessage{
+		Doctype: consts.Files, ReconcileDirID: kb.DocID,
+	})
+	require.NoError(t, err, "a content duplicate does not fail the reconcile job")
+
+	indexed := r.fake.FileIDs()
+	require.Len(t, indexed, 2, "the file with its own content, and one of the two copies")
+	assert.Contains(t, indexed, other.DocID)
+	dup := b
+	if !slices.Contains(indexed, a.DocID) {
+		dup = a
+	}
+	assert.NotContains(t, indexed, dup.DocID, "the second copy of the content is not indexed")
+	path := "/indexer/partition/" + r.inst.Domain + "/file/" + dup.DocID
+	assert.Equal(t, 1, r.fake.Rec.Count(http.MethodPost, path), "one POST, refused with a 409")
+	assert.Equal(t, 0, r.fake.Rec.Count(http.MethodPut, path))
+
+	// The workspace exists now: the following feed job pushes no reconcile
+	// job. It carries the three files, so openRAG is offered the duplicate
+	// once more (and refuses it once more, at the cost of one upload); it is
+	// never asked for a PUT, and the batch still succeeds.
+	r.runUntilSettled()
+	assert.Empty(t, r.reconciles)
+	assert.Equal(t, 0, r.fake.Rec.Count(http.MethodPut, path))
+	assert.ElementsMatch(t, indexed, r.fake.FileIDs())
+}
+
+// TestReconcileSkipsFileWithMissingContent covers a file whose content
+// vanished from local storage (observed on the test instance: "open
+// …/TestDocs/test-docs.md: no such file or directory"). resolveContent then
+// gets os.ErrNotExist from the VFS: that content will never come back, so
+// the file must be skipped like an indexer refusal, not retried like a
+// transient read error.
+func TestReconcileSkipsFileWithMissingContent(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	broken := r.writeFile("/KB/broken.txt", "will vanish")
+	good := r.writeFile("/KB/good.txt", "good")
+	r.addAssistant("KB assistant", kb.DocID)
+	// Remove the content from the instance's storage but keep the file
+	// document: exactly what a lost storage write leaves behind.
+	require.NoError(t, vfsafero.GetMemFS(r.inst.Domain).Remove("/KB/broken.txt"))
+
+	err := rag.Index(r.inst, rag.TestingLogger(), rag.IndexMessage{
+		Doctype: consts.Files, ReconcileDirID: kb.DocID,
+	})
+
+	require.NoError(t, err, "content missing on disk is a definitive skip, not a retry")
+	_, ok := r.fake.File(good.DocID)
+	assert.True(t, ok, "the walk continued past the file with missing content")
+	_, ok = r.fake.File(broken.DocID)
+	assert.False(t, ok, "the file with missing content is not indexed")
+	path := "/indexer/partition/" + r.inst.Domain + "/file/" + broken.DocID
+	assert.Zero(t, r.fake.Rec.Count(http.MethodPost, path), "content that cannot be read is never uploaded")
+	assert.Zero(t, r.fake.Rec.Count(http.MethodPut, path))
+}
+
+// TestIndexWorkspaceListingFailureIsRetryable covers the "openRAG workspace
+// listing fails" edge case: the diff must not run on a partial view, so the
+// job fails with nothing indexed, nothing detached and the checkpoint held.
+// Every status but 404 (no partition yet) qualifies, a 4xx as much as a 5xx:
+// an unreadable listing is never "the partition holds no workspace".
+func TestIndexWorkspaceListingFailureIsRetryable(t *testing.T) {
+	for _, status := range []int{http.StatusInternalServerError, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			r := newRAGTest(t)
+			kb := r.mkdir("/KB")
+			doc := r.writeFile("/KB/a.txt", "alpha")
+			r.addAssistant("KB assistant", kb.DocID)
+			// A workspace and a file a run on a partial view would wrongly delete.
+			r.fake.AddWorkspace("old-kb")
+			r.fake.AddFile("ghost", "x", "old-kb")
+
+			r.fake.Fail = func(method, path string) int {
+				if method == http.MethodGet && path == "/partition/"+r.inst.Domain+"/workspaces" {
+					return status
+				}
+				return 0
+			}
+			err := r.index()
+			require.Error(t, err)
+
+			lastSeq, _ := r.checkpoint()
+			assert.Empty(t, lastSeq, "the checkpoint is held")
+			assert.Equal(t, []string{"ghost"}, r.fake.FileIDs(), "nothing indexed, nothing deleted")
+			assert.True(t, r.fake.HasWorkspace("old-kb"), "no workspace removed on a partial view")
+			assert.False(t, r.fake.HasWorkspace(kb.DocID), "no workspace created either")
+			assert.Equal(t, 0, r.uploads(doc))
+		})
+	}
+}
+
+// TestIndexWorkspaceListingNotFoundIsEmpty covers the cold start: openRAG
+// has no partition for the instance yet and answers 404 on the workspace
+// listing. That is "no workspace", not a failure: the diff creates them,
+// the partition along the way, and the batch indexes.
+func TestIndexWorkspaceListingNotFoundIsEmpty(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+	// The fake knows no partition; a real openRAG answers 404 on the listing
+	// until the partition is created with the first workspace.
+	r.fake.Fail = func(method, path string) int {
+		if method == http.MethodGet && path == "/partition/"+r.inst.Domain+"/workspaces" {
+			return http.StatusNotFound
+		}
+		return 0
+	}
+
+	r.runUntilSettled()
+
+	assert.True(t, r.fake.HasWorkspace(kb.DocID), "the workspace is created on a cold partition")
+	assert.Equal(t, 1, r.fake.Rec.Count(http.MethodPost, "/partition/"+r.inst.Domain), "the partition was created")
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok, "and the file indexed")
+	assert.Equal(t, []string{kb.DocID}, ff.Workspaces)
+	lastSeq, _ := r.checkpoint()
+	assert.NotEmpty(t, lastSeq)
+}
+
+// TestIndexScopeLoadingFailureIsRetryable covers the "the scopes cannot be
+// read" edge case: the job fails without touching the checkpoint nor
+// openRAG, so a later run indexes on a complete view of the scopes.
+func TestIndexScopeLoadingFailureIsRetryable(t *testing.T) {
+	r := newRAGTest(t)
+	r.mkdir("/KB")
+	r.writeFile("/KB/a.txt", "alpha")
+	// An id starting with "_" is rejected by couchdb before any HTTP
+	// round-trip: the lookup fails deterministically, and it is not a
+	// not-found.
+	r.addAssistant("Broken", "_bogus")
+
+	err := r.index()
+	require.Error(t, err)
+	lastSeq, _ := r.checkpoint()
+	assert.Empty(t, lastSeq, "the checkpoint is held")
+	assert.Empty(t, r.fake.FileIDs(), "nothing was indexed on a partial view")
+}
+
+func TestIndexMessageJSON(t *testing.T) {
+	raw, err := json.Marshal(rag.IndexMessage{Doctype: consts.Files})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"doctype":"io.cozy.files"}`, string(raw))
+	raw, err = json.Marshal(rag.IndexMessage{Doctype: consts.Files, ReconcileDirID: "x"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"doctype":"io.cozy.files","reconcile_dir_id":"x"}`, string(raw))
+}

--- a/model/rag/index_test.go
+++ b/model/rag/index_test.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/cozy/cozy-stack/model/feature"
 	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,4 +64,75 @@ func TestIsClassAllowed(t *testing.T) {
 		assert.False(t, isClassAllowed(off, class), class)
 		assert.True(t, isClassAllowed(on, class), class)
 	}
+}
+
+// TestUploadMetaCreatedAt pins that the creation date of the file document
+// reaches the RAG server, whether the file comes from the changes feed or
+// from a VFS document, in the RFC 3339 form CouchDB stores it in.
+func TestUploadMetaCreatedAt(t *testing.T) {
+	created := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	doc := &vfs.FileDoc{
+		DocID:     "a1b2c3",
+		DocRev:    "3-abc",
+		CreatedAt: created,
+		UpdatedAt: created.Add(time.Hour),
+		Metadata:  vfs.Metadata{"datetime": "2026-03-01T00:00:00Z"},
+	}
+
+	t.Run("from a VFS document", func(t *testing.T) {
+		meta := uploadMeta(fileInfoFromDoc(doc))
+		assert.Equal(t, "2026-03-04T05:06:07Z", meta["created_at"])
+		assert.Equal(t, "2026-03-01T00:00:00Z", meta["datetime"])
+		assert.Equal(t, "3-abc", meta["doc_rev"])
+		assert.Equal(t, consts.Files, meta["doctype"])
+	})
+
+	t.Run("from the changes feed", func(t *testing.T) {
+		raw, err := json.Marshal(doc)
+		require.NoError(t, err)
+		var change couchdb.Change
+		change.DocID = doc.DocID
+		require.NoError(t, json.Unmarshal(raw, &change.Doc))
+
+		meta := uploadMeta(fileInfoFromChange(change))
+		assert.Equal(t, "2026-03-04T05:06:07Z", meta["created_at"])
+		assert.Equal(t, "2026-03-01T00:00:00Z", meta["datetime"])
+	})
+
+	t.Run("a file without a creation date sends none", func(t *testing.T) {
+		meta := uploadMeta(fileInfo{})
+		assert.Empty(t, meta["created_at"])
+	})
+}
+
+// TestClassifyConflict pins the two 409 openRAG answers on the upload route,
+// captured against the real server: the id it already holds (a PUT fixes it)
+// and the content it already indexed under another id (nothing fixes it).
+func TestClassifyConflict(t *testing.T) {
+	t.Run("the file id already exists", func(t *testing.T) {
+		body := []byte(`{"detail":"File 'abc123' already exists in partition alice.cozy.example"}`)
+		conflict, existingID := classifyConflict(body)
+		assert.Equal(t, conflictIDExists, conflict)
+		assert.Empty(t, existingID)
+	})
+
+	t.Run("the content already exists", func(t *testing.T) {
+		body := []byte(`{"detail":"[DOCUMENT_CONTENT_EXISTS]: This document already exists in partition 'alice.cozy.example'.","extra":{"existing_file_id":"other456","request_id":"r-1"}}`)
+		conflict, existingID := classifyConflict(body)
+		assert.Equal(t, conflictContentExists, conflict)
+		assert.Equal(t, "other456", existingID)
+	})
+
+	t.Run("an unknown body", func(t *testing.T) {
+		for _, body := range []string{
+			`{"detail":"the partition is locked"}`,
+			`{"detail":[{"loc":["body"],"msg":"nope"}]}`,
+			`<html>409</html>`,
+			``,
+		} {
+			conflict, existingID := classifyConflict([]byte(body))
+			assert.Equal(t, conflictUnknown, conflict, body)
+			assert.Empty(t, existingID, body)
+		}
+	})
 }

--- a/model/rag/membership.go
+++ b/model/rag/membership.go
@@ -1,0 +1,124 @@
+package rag
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/labstack/echo/v4"
+)
+
+// fileWorkspaces returns the workspaces openRAG lists for the file. found is
+// false when openRAG does not know the file.
+func fileWorkspaces(server config.RAGServer, domain, fileID string) ([]string, bool, error) {
+	res, err := callRAG(server, http.MethodGet, nil, fmt.Sprintf("/partition/%s/files/%s/workspaces", domain, url.PathEscape(fileID)), echo.MIMEApplicationJSON)
+	if err != nil {
+		return nil, false, retryable(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		return nil, false, nil
+	}
+	if err := statusError("GET file workspaces", res.StatusCode); err != nil {
+		return nil, false, err
+	}
+	var body struct {
+		WorkspaceIDs []string `json:"workspace_ids"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		return nil, false, err
+	}
+	return body.WorkspaceIDs, true, nil
+}
+
+func addMembership(server config.RAGServer, domain, workspaceID, fileID string) error {
+	body, err := json.Marshal(map[string]interface{}{"file_ids": []string{fileID}})
+	if err != nil {
+		return err
+	}
+	res, err := callRAG(server, http.MethodPost, body, fmt.Sprintf("/partition/%s/workspaces/%s/files", domain, url.PathEscape(workspaceID)), echo.MIMEApplicationJSON)
+	if err != nil {
+		return retryable(err)
+	}
+	res.Body.Close()
+	return statusError("POST workspace file", res.StatusCode)
+}
+
+func removeMembership(server config.RAGServer, domain, workspaceID, fileID string) error {
+	res, err := callRAG(server, http.MethodDelete, nil, fmt.Sprintf("/partition/%s/workspaces/%s/files/%s", domain, url.PathEscape(workspaceID), url.PathEscape(fileID)), echo.MIMEApplicationJSON)
+	if err != nil {
+		return retryable(err)
+	}
+	res.Body.Close()
+	return statusError("DELETE workspace file", res.StatusCode, http.StatusNotFound)
+}
+
+// syncMembership makes the file's memberships equal to desired: missing
+// ones are added, extra ones removed. A file openRAG does not know yet
+// (asynchronous indexing) is skipped: the upload carried the memberships.
+func syncMembership(server config.RAGServer, domain, fileID string, desired []string) error {
+	current, found, err := fileWorkspaces(server, domain, fileID)
+	if err != nil || !found {
+		return err
+	}
+	for _, id := range desired {
+		if !slices.Contains(current, id) {
+			if err := addMembership(server, domain, id, fileID); err != nil {
+				return err
+			}
+		}
+	}
+	for _, id := range current {
+		if !slices.Contains(desired, id) {
+			if err := removeMembership(server, domain, id, fileID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// detachFileHTTP removes the file from the workspace, then deletes it from
+// openRAG when no membership remains. It reports whether the file was deleted.
+func detachFileHTTP(server config.RAGServer, domain, fileID, workspaceID string, logger logger.Logger) (bool, error) {
+	ids, found, err := fileWorkspaces(server, domain, fileID)
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		return false, nil
+	}
+	remaining := 0
+	for _, id := range ids {
+		if id == workspaceID {
+			if err := removeMembership(server, domain, workspaceID, fileID); err != nil {
+				return false, err
+			}
+			continue
+		}
+		remaining++
+	}
+	if remaining > 0 {
+		return false, nil
+	}
+	logger.Debugf("file %s belongs to no knowledge base any more: deleting it from openRAG", fileID)
+	if err := deleteFromRAGHTTP(server, domain, fileID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// detachFile is detachFileHTTP on the instance's RAG server, plus the index
+// status cleanup when the file was deleted from openRAG.
+func detachFile(inst *instance.Instance, fileID, workspaceID string, logger logger.Logger) error {
+	deleted, err := detachFileHTTP(inst.RAGServer(), inst.Domain, fileID, workspaceID, logger)
+	if err != nil || !deleted {
+		return err
+	}
+	return DeleteIndexStatus(inst, fileID)
+}

--- a/model/rag/membership_http_test.go
+++ b/model/rag/membership_http_test.go
@@ -1,0 +1,129 @@
+package rag
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexedMD5SumRetryable(t *testing.T) {
+	fake := NewFakeOpenRAG(t)
+	fake.AddFile("f1", "abc")
+	fake.Fail = func(method, path string) int { return 503 }
+	_, _, err := indexedMD5Sum(fake.Server, "dom", "f1")
+	require.Error(t, err)
+	assert.True(t, isRetryable(err))
+}
+
+func TestDeleteFromRAGHTTPRetryable(t *testing.T) {
+	fake := NewFakeOpenRAG(t)
+	fake.AddFile("f1", "abc")
+	require.NoError(t, deleteFromRAGHTTP(fake.Server, "dom", "f1"))
+	_, ok := fake.File("f1")
+	assert.False(t, ok)
+	require.NoError(t, deleteFromRAGHTTP(fake.Server, "dom", "f1"), "404 is tolerated")
+
+	fake.Fail = func(method, path string) int { return 500 }
+	err := deleteFromRAGHTTP(fake.Server, "dom", "f1")
+	require.Error(t, err)
+	assert.True(t, isRetryable(err))
+}
+
+func TestDetachFileHTTP(t *testing.T) {
+	t.Run("removes the membership and deletes an unclaimed file", func(t *testing.T) {
+		fake := NewFakeOpenRAG(t)
+		fake.AddWorkspace("ws")
+		fake.AddFile("f1", "abc", "ws")
+
+		deleted, err := detachFileHTTP(fake.Server, "dom", "f1", "ws", TestingLogger())
+		require.NoError(t, err)
+		assert.True(t, deleted)
+		_, ok := fake.File("f1")
+		assert.False(t, ok)
+	})
+
+	t.Run("keeps a file still claimed by another workspace", func(t *testing.T) {
+		fake := NewFakeOpenRAG(t)
+		fake.AddWorkspace("ws")
+		fake.AddWorkspace("other")
+		fake.AddFile("f1", "abc", "ws", "other")
+
+		deleted, err := detachFileHTTP(fake.Server, "dom", "f1", "ws", TestingLogger())
+		require.NoError(t, err)
+		assert.False(t, deleted)
+		ff, ok := fake.File("f1")
+		require.True(t, ok)
+		assert.Equal(t, []string{"other"}, ff.Workspaces)
+	})
+
+	t.Run("deletes an indexed file that belongs to no workspace", func(t *testing.T) {
+		fake := NewFakeOpenRAG(t)
+		fake.AddWorkspace("ws")
+		fake.AddFile("f1", "abc")
+
+		deleted, err := detachFileHTTP(fake.Server, "dom", "f1", "ws", TestingLogger())
+		require.NoError(t, err)
+		assert.True(t, deleted)
+		_, ok := fake.File("f1")
+		assert.False(t, ok)
+		assert.Equal(t, 0, fake.Rec.Count(http.MethodDelete, "/partition/dom/workspaces/ws/files/f1"), "nothing to remove")
+	})
+
+	t.Run("does nothing for a file openRAG does not know", func(t *testing.T) {
+		fake := NewFakeOpenRAG(t)
+		deleted, err := detachFileHTTP(fake.Server, "dom", "nope", "ws", TestingLogger())
+		require.NoError(t, err)
+		assert.False(t, deleted)
+		assert.Equal(t, 0, fake.Rec.Count(http.MethodDelete, "/indexer/partition/dom/file/nope"))
+	})
+
+	t.Run("5xx on the membership listing is retryable and mutates nothing", func(t *testing.T) {
+		fake := NewFakeOpenRAG(t)
+		fake.AddWorkspace("ws")
+		fake.AddFile("f1", "abc", "ws")
+		fake.Fail = func(method, path string) int {
+			if method == http.MethodGet {
+				return 502
+			}
+			return 0
+		}
+		_, err := detachFileHTTP(fake.Server, "dom", "f1", "ws", TestingLogger())
+		require.Error(t, err)
+		assert.True(t, isRetryable(err))
+		ff, ok := fake.File("f1")
+		require.True(t, ok)
+		assert.Equal(t, []string{"ws"}, ff.Workspaces)
+	})
+}
+
+func TestSyncMembership(t *testing.T) {
+	t.Run("adds the missing and removes the extra memberships", func(t *testing.T) {
+		fake := NewFakeOpenRAG(t)
+		fake.AddWorkspace("keep")
+		fake.AddWorkspace("add")
+		fake.AddWorkspace("drop")
+		fake.AddFile("f1", "abc", "keep", "drop")
+
+		require.NoError(t, syncMembership(fake.Server, "dom", "f1", []string{"add", "keep"}))
+
+		ff, _ := fake.File("f1")
+		assert.ElementsMatch(t, []string{"keep", "add"}, ff.Workspaces)
+	})
+
+	t.Run("does nothing for a file openRAG does not know", func(t *testing.T) {
+		fake := NewFakeOpenRAG(t)
+		fake.AddWorkspace("ws")
+		require.NoError(t, syncMembership(fake.Server, "dom", "nope", []string{"ws"}))
+		assert.Equal(t, 0, fake.Rec.Count(http.MethodPost, "/partition/dom/workspaces/ws/files"))
+	})
+
+	t.Run("no request when already in sync", func(t *testing.T) {
+		fake := NewFakeOpenRAG(t)
+		fake.AddWorkspace("ws")
+		fake.AddFile("f1", "abc", "ws")
+		require.NoError(t, syncMembership(fake.Server, "dom", "f1", []string{"ws"}))
+		assert.Len(t, fake.Rec.All(), 1, "only the listing")
+	})
+}

--- a/model/rag/prune.go
+++ b/model/rag/prune.go
@@ -1,0 +1,219 @@
+package rag
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"slices"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/job"
+	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/labstack/echo/v4"
+)
+
+// ErrUnknownFolder is returned by Reconcile when the given folder is in no
+// assistant's knowledge base: there is nothing to index in it.
+var ErrUnknownFolder = errors.New("the folder is in no assistant's knowledge base")
+
+// PruneResult summarizes a Prune run.
+type PruneResult struct {
+	FilesScanned      int `json:"files_scanned"`
+	FilesDeleted      int `json:"files_deleted"`
+	WorkspacesDeleted int `json:"workspaces_deleted"`
+}
+
+// claimsFile tells whether a knowledge base folder claims the file: it must
+// be live in the VFS, with a parent directory inside such a folder.
+func (s *scopes) claimsFile(fs vfs.VFS, fileID string) (bool, error) {
+	file, err := fs.FileByID(fileID)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if file.Trashed {
+		return false, nil
+	}
+	parentPath, err := s.dirs.path(fs, file.DirID)
+	if errors.Is(err, os.ErrNotExist) {
+		// The parent directory is gone: the file is orphaned.
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return len(s.desiredFor(parentPath)) > 0, nil
+}
+
+// listPartitionFiles returns the ids of the files openRAG holds for the
+// instance. openRAG answers with links to each file; the id is the last
+// path segment of the link.
+func listPartitionFiles(server config.RAGServer, domain string) ([]string, error) {
+	res, err := callRAG(server, http.MethodGet, nil, fmt.Sprintf("/partition/%s/", domain), echo.MIMEApplicationJSON)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if err := statusError("GET partition", res.StatusCode); err != nil {
+		return nil, err
+	}
+	var body struct {
+		Files []struct {
+			Link string `json:"link"`
+		} `json:"files"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(body.Files))
+	for _, f := range body.Files {
+		if id := path.Base(f.Link); id != "" && id != "." && id != "/" {
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
+}
+
+// Prune deletes from openRAG what no knowledge base folder claims any more:
+// the files gone or trashed in the VFS, the files outside every knowledge
+// base folder, and the workspaces of the folders that are in no knowledge
+// base. The index status of a deleted file is dropped too.
+func Prune(inst *instance.Instance, logger logger.Logger) (PruneResult, error) {
+	var result PruneResult
+	server := inst.RAGServer()
+	if server.URL == "" {
+		return result, errors.New("no RAG server configured")
+	}
+	sc, err := loadScopes(inst, logger)
+	if err != nil {
+		return result, err
+	}
+	workspaces, err := listWorkspaces(server, inst.Domain)
+	if err != nil {
+		return result, err
+	}
+	// diffWorkspaces works on folder ids; what openRAG holds and what the
+	// cleanup below deletes are workspace ids.
+	_, staleFolders := diffWorkspaces(sc.folders, dirIDsForWorkspaces(workspaces))
+	stale := workspaceIDsForDirs(staleFolders)
+	ids, err := listPartitionFiles(server, inst.Domain)
+	if err != nil {
+		return result, err
+	}
+	fs := inst.VFS()
+	for _, id := range ids {
+		result.FilesScanned++
+		keep, err := sc.claimsFile(fs, id)
+		if err != nil {
+			return result, err
+		}
+		if keep {
+			// openRAG deletes the files a workspace deletion leaves without
+			// any workspace: a kept file must leave the stale workspaces
+			// first, or the cleanup below would take it along.
+			if len(stale) > 0 {
+				if err := removeMemberships(server, inst.Domain, id, stale); err != nil {
+					return result, err
+				}
+			}
+			continue
+		}
+		logger.Infof("prune: deleting unclaimed file %s from openRAG", id)
+		if err := deleteFromRAG(inst, id); err != nil {
+			return result, err
+		}
+		result.FilesDeleted++
+	}
+	for _, id := range stale {
+		logger.Infof("prune: deleting workspace %s of a folder in no knowledge base", id)
+		if err := deleteWorkspace(server, inst.Domain, id); err != nil {
+			return result, err
+		}
+		result.WorkspacesDeleted++
+	}
+	return result, nil
+}
+
+// removeMemberships takes the file out of those of the given workspaces it
+// is a member of.
+func removeMemberships(server config.RAGServer, domain, fileID string, workspaces []string) error {
+	current, found, err := fileWorkspaces(server, domain, fileID)
+	if err != nil || !found {
+		return err
+	}
+	for _, ws := range current {
+		if !slices.Contains(workspaces, ws) {
+			continue
+		}
+		if err := removeMembership(server, domain, ws, fileID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// resetCheckpoint deletes the checkpoint under the lock the rag-index jobs
+// take, so a batch already running cannot save its own LastSeq over the
+// reset.
+func resetCheckpoint(inst *instance.Instance) error {
+	mu := config.Lock().LongOperation(inst, indexLockName)
+	if err := mu.Lock(); err != nil {
+		return err
+	}
+	defer mu.Unlock()
+	return deleteCheckpoint(inst, consts.Files, checkpointDocID)
+}
+
+// Reset drops the checkpoint and launches a rag-index job, forcing a full
+// re-index from the beginning of the changes feed.
+func Reset(inst *instance.Instance) error {
+	if err := resetCheckpoint(inst); err != nil {
+		return err
+	}
+	msg, err := job.NewMessage(IndexMessage{Doctype: consts.Files})
+	if err != nil {
+		return err
+	}
+	_, err = job.System().PushJob(inst, &job.JobRequest{
+		WorkerType: workerType,
+		Message:    msg,
+		Manual:     true,
+	})
+	return err
+}
+
+// Reconcile pushes a reconcile job for the knowledge base folder, or one per
+// knowledge base folder when dirID is empty. It returns the number of jobs
+// pushed.
+func Reconcile(inst *instance.Instance, dirID string) (int, error) {
+	sc, err := loadScopes(inst, inst.Logger().WithNamespace("rag"))
+	if err != nil {
+		return 0, err
+	}
+	folders := sc.folderIDs()
+	if dirID != "" {
+		if _, ok := sc.folders[dirID]; !ok {
+			return 0, ErrUnknownFolder
+		}
+		folders = []string{dirID}
+	}
+	n := 0
+	for _, id := range folders {
+		// pushReconcileJob on purpose, not the pushReconcile variable: the
+		// variable only exists so the tests of Index can record the pushes,
+		// while TestReconcile exercises the real job push.
+		if err := pushReconcileJob(inst, id); err != nil {
+			return n, err
+		}
+		n++
+	}
+	return n, nil
+}

--- a/model/rag/prune_test.go
+++ b/model/rag/prune_test.go
@@ -1,0 +1,208 @@
+package rag_test
+
+import (
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/job"
+	"github.com/cozy/cozy-stack/model/rag"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrune(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	r.mkdir("/Other")
+	claimed := r.writeFile("/KB/a.txt", "alpha")
+	unclaimed := r.writeFile("/Other/c.txt", "gamma")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+
+	// Simulate leftovers: a file of a folder in no knowledge base, and a
+	// file that no longer exists in the VFS.
+	r.fake.AddFile(unclaimed.DocID, "x")
+	r.fake.AddFile("ghost", "y")
+
+	res, err := rag.Prune(r.inst, rag.TestingLogger())
+	require.NoError(t, err)
+	assert.Equal(t, rag.PruneResult{FilesScanned: 3, FilesDeleted: 2}, res)
+	_, ok := r.fake.File(claimed.DocID)
+	assert.True(t, ok)
+	_, ok = r.fake.File(unclaimed.DocID)
+	assert.False(t, ok)
+	_, ok = r.fake.File("ghost")
+	assert.False(t, ok)
+}
+
+func TestPruneWithRootAssistant(t *testing.T) {
+	r := newRAGTest(t)
+	r.mkdir("/Other")
+	doc := r.writeFile("/Other/c.txt", "gamma")
+	r.addAssistant("Everything", consts.RootDirID)
+	r.fake.AddWorkspace(rag.RootWorkspaceID)
+	r.fake.AddFile(doc.DocID, "x", rag.RootWorkspaceID)
+	r.fake.AddFile("ghost", "y")
+
+	res, err := rag.Prune(r.inst, rag.TestingLogger())
+	require.NoError(t, err)
+	assert.Equal(t, rag.PruneResult{FilesScanned: 2, FilesDeleted: 1}, res)
+	_, ok := r.fake.File(doc.DocID)
+	assert.True(t, ok, "claimed by the root assistant")
+	assert.True(t, r.fake.HasWorkspace(rag.RootWorkspaceID), "the whole-Drive workspace is the root folder's")
+}
+
+// TestPruneDropsStaleRootWorkspace: the whole-Drive workspace is resolved
+// back to the root folder, which no assistant uses any more.
+func TestPruneDropsStaleRootWorkspace(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+	r.fake.AddWorkspace(rag.RootWorkspaceID)
+	r.fake.AddFile(doc.DocID, "x", kb.DocID, rag.RootWorkspaceID)
+
+	res, err := rag.Prune(r.inst, rag.TestingLogger())
+	require.NoError(t, err)
+	assert.Equal(t, rag.PruneResult{FilesScanned: 1, WorkspacesDeleted: 1}, res)
+	assert.False(t, r.fake.HasWorkspace(rag.RootWorkspaceID))
+	assert.True(t, r.fake.HasWorkspace(kb.DocID))
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok, "the file is still claimed by /KB: its membership was removed first")
+	assert.Equal(t, []string{kb.DocID}, ff.Workspaces)
+}
+
+// TestPruneOrphanedFileIsDeleted covers the "not found" branch of the
+// parent directory lookup: the directory doc is gone (deleted outside the
+// VFS, bypassing trash), so the file is orphaned and pruned even though the
+// root assistant would otherwise claim it.
+func TestPruneOrphanedFileIsDeleted(t *testing.T) {
+	r := newRAGTest(t)
+	orphan := r.mkdir("/Orphan")
+	doc := r.writeFile("/Orphan/o.txt", "epsilon")
+	r.addAssistant("Everything", consts.RootDirID)
+	r.fake.AddFile(doc.DocID, "x")
+
+	// Delete the directory doc directly, bypassing VFS trash semantics, so
+	// the file's dir_id now points at nothing.
+	require.NoError(t, couchdb.DeleteDoc(r.inst, orphan))
+
+	res, err := rag.Prune(r.inst, rag.TestingLogger())
+	require.NoError(t, err)
+	assert.Equal(t, rag.PruneResult{FilesScanned: 1, FilesDeleted: 1}, res)
+	_, ok := r.fake.File(doc.DocID)
+	assert.False(t, ok, "the file's parent directory is gone: orphaned")
+}
+
+// TestPruneAbortsOnDirLookupError covers the "any other error" branch: a
+// directory lookup failure that is not a not-found (here: an id starting
+// with "_", rejected by couchdb before any HTTP round-trip, so the failure
+// is deterministic) must abort the prune rather than delete the file.
+func TestPruneAbortsOnDirLookupError(t *testing.T) {
+	r := newRAGTest(t)
+	r.mkdir("/KB")
+	doc := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("Everything", consts.RootDirID)
+	r.fake.AddFile(doc.DocID, "x")
+
+	raw, err := r.inst.VFS().FileByID(doc.DocID)
+	require.NoError(t, err)
+	raw.DirID = "_bogus"
+	require.NoError(t, couchdb.UpdateDoc(r.inst, raw))
+
+	_, err = rag.Prune(r.inst, rag.TestingLogger())
+	require.Error(t, err)
+	_, ok := r.fake.File(doc.DocID)
+	assert.True(t, ok, "the prune aborted before touching openRAG")
+}
+
+func TestPruneDropsWorkspacesWithoutAssistant(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	inKB := r.writeFile("/KB/a.txt", "alpha")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+
+	// A workspace whose folder is in no knowledge base, still holding a file
+	// that the live workspace also holds.
+	r.fake.AddWorkspace("old-kb")
+	r.fake.AddFile(inKB.DocID, "x", kb.DocID, "old-kb")
+
+	res, err := rag.Prune(r.inst, rag.TestingLogger())
+	require.NoError(t, err)
+	assert.Equal(t, rag.PruneResult{FilesScanned: 1, WorkspacesDeleted: 1}, res)
+	assert.False(t, r.fake.HasWorkspace("old-kb"))
+	assert.True(t, r.fake.HasWorkspace(kb.DocID), "the workspace of the live folder is kept")
+	ff, ok := r.fake.File(inKB.DocID)
+	require.True(t, ok, "the file is claimed by the live folder")
+	assert.Equal(t, []string{kb.DocID}, ff.Workspaces)
+}
+
+func TestPruneKeepsClaimedFilesOfDroppedWorkspace(t *testing.T) {
+	r := newRAGTest(t)
+	r.mkdir("/Docs")
+	doc := r.writeFile("/Docs/a.txt", "alpha")
+	r.addAssistant("Everything", consts.RootDirID)
+	// The folder used to be a knowledge base: no assistant references it any
+	// more, the workspace and the membership are still there.
+	r.fake.AddWorkspace("old-kb")
+	r.fake.AddFile(doc.DocID, "x", "old-kb")
+
+	res, err := rag.Prune(r.inst, rag.TestingLogger())
+	require.NoError(t, err)
+	assert.Equal(t, rag.PruneResult{FilesScanned: 1, WorkspacesDeleted: 1}, res)
+	assert.False(t, r.fake.HasWorkspace("old-kb"))
+	ff, ok := r.fake.File(doc.DocID)
+	require.True(t, ok, "openRAG would have deleted it with the workspace: the membership was removed first")
+	assert.Empty(t, ff.Workspaces)
+}
+
+func TestReset(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+	lastSeq, _ := r.checkpoint()
+	require.NotEmpty(t, lastSeq)
+
+	require.NoError(t, rag.Reset(r.inst))
+
+	lastSeq, _ = r.checkpoint()
+	assert.Empty(t, lastSeq)
+
+	jobs, err := job.GetAllJobs(r.inst)
+	require.NoError(t, err)
+	var ragJobs []*job.Job
+	for _, j := range jobs {
+		if j.WorkerType == "rag-index" {
+			ragJobs = append(ragJobs, j)
+		}
+	}
+	require.Len(t, ragJobs, 1, "a single rag-index job was pushed")
+	assert.JSONEq(t, `{"doctype":"io.cozy.files"}`, string(ragJobs[0].Message))
+	assert.True(t, ragJobs[0].Manual)
+}
+
+func TestReconcile(t *testing.T) {
+	r := newRAGTest(t)
+	dirA := r.mkdir("/A")
+	dirB := r.mkdir("/B")
+	r.addAssistant("A", dirA.DocID)
+	r.addAssistant("B", dirB.DocID)
+
+	n, err := rag.Reconcile(r.inst, dirA.DocID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	n, err = rag.Reconcile(r.inst, "")
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "without dir_id every knowledge base folder is reconciled")
+
+	_, err = rag.Reconcile(r.inst, dirB.DocID)
+	require.NoError(t, err)
+
+	_, err = rag.Reconcile(r.inst, "not-a-knowledge-base")
+	assert.ErrorIs(t, err, rag.ErrUnknownFolder)
+}

--- a/model/rag/purge.go
+++ b/model/rag/purge.go
@@ -1,0 +1,55 @@
+package rag
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/labstack/echo/v4"
+)
+
+// Purge deletes everything openRAG holds for the instance: its workspaces,
+// its files and the partition itself. The index statuses are dropped, and
+// so is the rag-index checkpoint, so that the next run indexes the whole
+// instance again from the beginning of the changes feed.
+func Purge(inst *instance.Instance, logger logger.Logger) error {
+	server := inst.RAGServer()
+	if server.URL == "" {
+		return errors.New("no RAG server configured")
+	}
+	// Workspaces are deleted one by one rather than left to the partition
+	// deletion, so that the result does not depend on openRAG cascading it.
+	workspaces, err := listWorkspaces(server, inst.Domain)
+	if err != nil {
+		return err
+	}
+	for _, id := range workspaces {
+		if err := deleteWorkspace(server, inst.Domain, id); err != nil {
+			return err
+		}
+	}
+	logger.Infof("purge: deleting the openRAG partition (%d workspaces dropped)", len(workspaces))
+	if err := deletePartition(server, inst.Domain); err != nil {
+		return err
+	}
+	if err := couchdb.DeleteDB(inst, consts.ChatRAG); err != nil && !couchdb.IsNotFoundError(err) {
+		return err
+	}
+	return resetCheckpoint(inst)
+}
+
+// deletePartition removes the instance's partition from openRAG, with every
+// file in it. A missing partition is fine.
+func deletePartition(server config.RAGServer, domain string) error {
+	res, err := callRAG(server, http.MethodDelete, nil, fmt.Sprintf("/partition/%s", domain), echo.MIMEApplicationJSON)
+	if err != nil {
+		return err
+	}
+	res.Body.Close()
+	return statusError("DELETE partition", res.StatusCode, http.StatusNotFound)
+}

--- a/model/rag/purge_test.go
+++ b/model/rag/purge_test.go
@@ -1,0 +1,38 @@
+package rag_test
+
+import (
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/rag"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPurge(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	r.mkdir("/Other")
+	inKB := r.writeFile("/KB/a.txt", "alpha")
+	r.writeFile("/Other/b.txt", "beta")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.runUntilSettled()
+	require.Equal(t, []string{inKB.DocID}, r.fake.FileIDs())
+	require.True(t, r.fake.HasWorkspace(kb.DocID))
+
+	require.NoError(t, rag.Purge(r.inst, rag.TestingLogger()))
+
+	assert.Empty(t, r.fake.FileIDs())
+	assert.False(t, r.fake.HasWorkspace(kb.DocID))
+	var status rag.IndexStatus
+	err := couchdb.GetDoc(r.inst, consts.ChatRAG, inKB.DocID, &status)
+	assert.True(t, couchdb.IsNotFoundError(err) || couchdb.IsNoDatabaseError(err), "index statuses are gone")
+	lastSeq, _ := r.checkpoint()
+	assert.Empty(t, lastSeq, "the checkpoint is dropped")
+
+	// The next run indexes everything again.
+	r.runUntilSettled()
+	assert.Equal(t, []string{inKB.DocID}, r.fake.FileIDs())
+	assert.True(t, r.fake.HasWorkspace(kb.DocID))
+}

--- a/model/rag/scope.go
+++ b/model/rag/scope.go
@@ -1,0 +1,141 @@
+package rag
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/couchdb"
+	"github.com/cozy/cozy-stack/pkg/logger"
+)
+
+// rootPath is the full path of the root directory of the VFS.
+const rootPath = "/"
+
+// underFolder tells whether a file whose parent directory has the given full
+// path is inside the folder with the given full path. Trashed content is
+// never inside, even when the folder itself is in the trash. The root folder
+// contains everything else.
+func underFolder(parentPath, folderPath string) bool {
+	if strings.HasPrefix(parentPath, vfs.TrashDirName) {
+		return false
+	}
+	if folderPath == rootPath {
+		return true
+	}
+	return parentPath == folderPath || strings.HasPrefix(parentPath, folderPath+"/")
+}
+
+// dirPathCache memoizes the full path of directories by id, for one run.
+type dirPathCache map[string]string
+
+// path resolves the full path of a directory. It returns os.ErrNotExist
+// when the directory is gone, and any other lookup error as is: callers
+// must treat the latter as "unknown", never as "out of scope".
+func (c dirPathCache) path(fs vfs.VFS, dirID string) (string, error) {
+	if p, ok := c[dirID]; ok {
+		return p, nil
+	}
+	if dirID == consts.RootDirID {
+		c[dirID] = rootPath
+		return rootPath, nil
+	}
+	dir, err := fs.DirByID(dirID)
+	if err != nil {
+		return "", err
+	}
+	c[dirID] = dir.Fullpath
+	return dir.Fullpath, nil
+}
+
+// scopes is the set of knowledge base folders of the assistants: what the
+// rag-index job indexes. It is used from a single goroutine and is not safe
+// for concurrent use.
+type scopes struct {
+	folders map[string]string // dir id → full path (rootPath for the root)
+	dirs    dirPathCache
+}
+
+// loadScopes reads the knowledge base folders of every assistant. A folder
+// that no longer exists is skipped with a warning; any other failure is
+// retryable: the scopes are unknown and nothing must be deleted on a guess.
+func loadScopes(inst *instance.Instance, logger logger.Logger) (*scopes, error) {
+	sc := &scopes{folders: map[string]string{}, dirs: dirPathCache{}}
+	err := couchdb.ForeachDocs(inst, consts.ChatAssistants, func(_ string, doc json.RawMessage) error {
+		var assistant chatAssistant
+		if err := json.Unmarshal(doc, &assistant); err != nil {
+			return err
+		}
+		for _, entry := range assistant.KnowledgeBase {
+			if entry.Doctype != consts.Files || entry.DirID == "" {
+				continue
+			}
+			if _, seen := sc.folders[entry.DirID]; seen {
+				continue
+			}
+			p, err := sc.dirs.path(inst.VFS(), entry.DirID)
+			if errors.Is(err, os.ErrNotExist) {
+				logger.Warnf("knowledge base folder %s of assistant %s does not exist: ignored", entry.DirID, assistant.DocID)
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			sc.folders[entry.DirID] = p
+		}
+		return nil
+	})
+	if err != nil && !couchdb.IsNoDatabaseError(err) {
+		return nil, retryable(err)
+	}
+	return sc, nil
+}
+
+// desiredFor returns, sorted, the ids of the knowledge base folders that
+// contain a file whose parent directory has the given full path.
+func (s *scopes) desiredFor(parentPath string) []string {
+	var ids []string
+	for dirID, folderPath := range s.folders {
+		if underFolder(parentPath, folderPath) {
+			ids = append(ids, dirID)
+		}
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// folderIDs returns the ids of the knowledge base folders, sorted.
+func (s *scopes) folderIDs() []string {
+	ids := make([]string, 0, len(s.folders))
+	for id := range s.folders {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// diffWorkspaces compares the knowledge base folders with the workspaces
+// openRAG holds: the folders without a workspace must get one, the
+// workspaces without a folder must go. Both results are sorted.
+func diffWorkspaces(folders map[string]string, existing []string) (toCreate, toRemove []string) {
+	existingSet := make(map[string]bool, len(existing))
+	for _, id := range existing {
+		existingSet[id] = true
+		if _, ok := folders[id]; !ok {
+			toRemove = append(toRemove, id)
+		}
+	}
+	for id := range folders {
+		if !existingSet[id] {
+			toCreate = append(toCreate, id)
+		}
+	}
+	slices.Sort(toCreate)
+	slices.Sort(toRemove)
+	return toCreate, toRemove
+}

--- a/model/rag/scope_test.go
+++ b/model/rag/scope_test.go
@@ -1,0 +1,50 @@
+package rag
+
+import (
+	"testing"
+
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnderFolder(t *testing.T) {
+	assert.True(t, underFolder("/Docs/KB", "/Docs/KB"))
+	assert.True(t, underFolder("/Docs/KB/sub", "/Docs/KB"))
+	assert.False(t, underFolder("/Docs/KB2", "/Docs/KB"))
+	assert.False(t, underFolder("/Docs", "/Docs/KB"))
+	assert.False(t, underFolder("/.cozy_trash/Docs/KB/sub", "/Docs/KB"))
+	assert.False(t, underFolder("/.cozy_trash/KB", "/.cozy_trash/KB"), "a trashed folder claims nothing")
+
+	assert.True(t, underFolder("/", "/"), "root claims files at the root")
+	assert.True(t, underFolder("/Docs/KB", "/"), "root claims everything")
+	assert.False(t, underFolder("/.cozy_trash/x", "/"), "root does not claim the trash")
+}
+
+func TestDesiredFor(t *testing.T) {
+	s := &scopes{folders: map[string]string{
+		"outer": "/Outer",
+		"inner": "/Outer/Inner",
+		"other": "/Other",
+	}}
+	assert.Equal(t, []string{"inner", "outer"}, s.desiredFor("/Outer/Inner/deep"))
+	assert.Equal(t, []string{"outer"}, s.desiredFor("/Outer"))
+	assert.Equal(t, []string{"other"}, s.desiredFor("/Other/x"))
+	assert.Empty(t, s.desiredFor("/Elsewhere"))
+	assert.Empty(t, s.desiredFor("/.cozy_trash/Outer/Inner"))
+
+	root := &scopes{folders: map[string]string{consts.RootDirID: "/", "inner": "/Outer/Inner"}}
+	assert.Equal(t, []string{"inner", consts.RootDirID}, root.desiredFor("/Outer/Inner"))
+	assert.Equal(t, []string{consts.RootDirID}, root.desiredFor("/Elsewhere"))
+	assert.Empty(t, (&scopes{folders: map[string]string{}}).desiredFor("/x"))
+}
+
+func TestDiffWorkspaces(t *testing.T) {
+	folders := map[string]string{"a": "/A", "b": "/B"}
+	toCreate, toRemove := diffWorkspaces(folders, []string{"b", "stale", "zzz"})
+	assert.Equal(t, []string{"a"}, toCreate)
+	assert.Equal(t, []string{"stale", "zzz"}, toRemove)
+
+	toCreate, toRemove = diffWorkspaces(map[string]string{}, []string{"x"})
+	assert.Empty(t, toCreate)
+	assert.Equal(t, []string{"x"}, toRemove)
+}

--- a/model/rag/workspace.go
+++ b/model/rag/workspace.go
@@ -6,489 +6,147 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"slices"
-	"strings"
 
 	"github.com/cozy/cozy-stack/model/instance"
-	"github.com/cozy/cozy-stack/model/vfs"
 	"github.com/cozy/cozy-stack/pkg/config/config"
 	"github.com/cozy/cozy-stack/pkg/consts"
-	"github.com/cozy/cozy-stack/pkg/couchdb"
 	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/labstack/echo/v4"
 )
 
-// workspaceBackfillChunkSize is the maximum number of file ids sent in a
-// single workspace membership backfill request.
-const workspaceBackfillChunkSize = 500
+// ErrWorkspaceMissing is returned by checkWorkspace when the knowledge base
+// folder has no workspace on openRAG: no rag-index job has reconciled it
+// yet.
+var ErrWorkspaceMissing = errors.New("the knowledge base folder is not indexed yet")
 
-// kbContext carries, for one rag-index batch, the knowledge-base folders
-// declared by assistants. Only folders that already exist as workspaces in
-// openRAG are kept (uploads may only reference existing workspaces). It is
-// only ever used from the single goroutine of one rag-index batch and is NOT
-// safe for concurrent use.
-type kbContext struct {
-	folders  map[string]string // dirID -> folder path
-	dirPaths map[string]string // dir_id -> path cache for the batch
+// rootWorkspaceID is the openRAG workspace id of the root folder, the
+// knowledge base of a whole-Drive assistant.
+const rootWorkspaceID = "io-cozy-files-root-dir"
+
+// wellKnownWorkspaceIDs maps the well-known folder ids of the VFS to the
+// workspace ids openRAG accepts. openRAG only takes ids matching
+// ^[A-Za-z0-9_-]+$ (422 otherwise), and these are the only folder ids with
+// dots: every other one is a hexadecimal CouchDB id, used as is. A user can
+// pick any of these directories as a knowledge base ("Shared with me" and
+// "Shared drives" are folders of their Drive), so all of them are mapped,
+// not just the root.
+var wellKnownWorkspaceIDs = map[string]string{
+	consts.RootDirID:           rootWorkspaceID,
+	consts.TrashDirID:          "io-cozy-files-trash-dir",
+	consts.SharedWithMeDirID:   "io-cozy-files-shared-with-me-dir",
+	consts.NoLongerSharedDirID: "io-cozy-files-no-longer-shared-dir",
+	consts.SharedDrivesDirID:   "io-cozy-files-shared-drives-dir",
 }
 
-func (kb *kbContext) empty() bool { return kb == nil || len(kb.folders) == 0 }
+// wellKnownDirIDs is wellKnownWorkspaceIDs read the other way round.
+var wellKnownDirIDs = invertWorkspaceIDs(wellKnownWorkspaceIDs)
 
-func (kb *kbContext) desiredWorkspaces(parentPath string) []string {
-	// Trashed content never belongs to a workspace, even when the KB folder
-	// itself was moved to the trash.
-	if strings.HasPrefix(parentPath, vfs.TrashDirName) {
-		return nil
+func invertWorkspaceIDs(table map[string]string) map[string]string {
+	inverse := make(map[string]string, len(table))
+	for dirID, workspaceID := range table {
+		inverse[workspaceID] = dirID
 	}
-	var ids []string
-	for dirID, folderPath := range kb.folders {
-		if parentPath == folderPath || strings.HasPrefix(parentPath, folderPath+"/") {
-			ids = append(ids, dirID)
-		}
+	return inverse
+}
+
+// workspaceIDForDir maps a knowledge base folder id to the id of its openRAG
+// workspace.
+func workspaceIDForDir(dirID string) string {
+	if id, ok := wellKnownWorkspaceIDs[dirID]; ok {
+		return id
 	}
-	slices.Sort(ids)
+	return dirID
+}
+
+// workspaceIDsForDirs maps folder ids to workspace ids, keeping the order.
+func workspaceIDsForDirs(dirIDs []string) []string {
+	ids := make([]string, len(dirIDs))
+	for i, dirID := range dirIDs {
+		ids[i] = workspaceIDForDir(dirID)
+	}
 	return ids
 }
 
-// desiredFor resolves the workspaces that should contain a file whose parent
-// directory is dirID. The boolean is false when the parent path could not be
-// resolved: callers must treat that as "unknown", never as "no membership"
-// (which would incorrectly detach the file from every workspace).
-func (kb *kbContext) desiredFor(inst *instance.Instance, dirID string) ([]string, bool) {
-	parentPath, ok := kb.parentPath(inst, dirID)
-	if !ok {
-		return nil, false
+// dirIDForWorkspace is the inverse of workspaceIDForDir: the folder id an
+// openRAG workspace id stands for.
+func dirIDForWorkspace(workspaceID string) string {
+	if dirID, ok := wellKnownDirIDs[workspaceID]; ok {
+		return dirID
 	}
-	return kb.desiredWorkspaces(parentPath), true
+	return workspaceID
 }
 
-// loadKBContext queries the assistants and the openRAG workspace list once
-// per batch. Any error yields a nil context: indexing proceeds without
-// membership reconciliation (best-effort by design). Note: once the KB
-// folders are known, a failure to list the existing openRAG workspaces also
-// yields nil, so that reconcileMembership does not mistake "we don't know"
-// for "none exist" and delete every current membership.
-func loadKBContext(inst *instance.Instance, logger logger.Logger) *kbContext {
-	kb := &kbContext{
-		folders:  map[string]string{},
-		dirPaths: map[string]string{},
+// dirIDsForWorkspaces maps workspace ids to folder ids, keeping the order.
+func dirIDsForWorkspaces(workspaceIDs []string) []string {
+	ids := make([]string, len(workspaceIDs))
+	for i, id := range workspaceIDs {
+		ids[i] = dirIDForWorkspace(id)
 	}
-	err := couchdb.ForeachDocs(inst, consts.ChatAssistants, func(_ string, doc json.RawMessage) error {
-		var assistant chatAssistant
-		if err := json.Unmarshal(doc, &assistant); err != nil {
-			return err
-		}
-		dirID := assistant.knowledgeBaseDirID(logger)
-		if dirID == "" {
-			return nil
-		}
-		dir, err := inst.VFS().DirByID(dirID)
-		if err != nil {
-			return nil
-		}
-		kb.folders[dirID] = dir.Fullpath
-		// Files directly inside a KB folder are the common layout: seed the
-		// per-batch path cache so parentPath does not re-fetch this dir.
-		kb.dirPaths[dirID] = dir.Fullpath
-		return nil
-	})
+	return ids
+}
+
+// workspaceExists tells whether the workspace exists on the openRAG server.
+func workspaceExists(server config.RAGServer, domain, id string) (bool, error) {
+	res, err := callRAG(server, http.MethodGet, nil, fmt.Sprintf("/partition/%s/workspaces/%s", domain, url.PathEscape(id)), echo.MIMEApplicationJSON)
 	if err != nil {
-		if !couchdb.IsNoDatabaseError(err) {
-			logger.Warnf("cannot load assistants for workspace sync: %s", err)
-		}
-		return nil
+		return false, retryable(err)
 	}
-	if len(kb.folders) == 0 {
-		return nil
+	res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		return false, nil
 	}
-	res, err := CallRAGQuery(inst, http.MethodGet, nil, fmt.Sprintf("/partition/%s/workspaces", inst.Domain), echo.MIMEApplicationJSON)
-	if err != nil {
-		logger.Warnf("cannot list RAG workspaces: %s", err)
-		return nil
+	if err := statusError("GET workspace", res.StatusCode); err != nil {
+		return false, err
 	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		logger.Warnf("cannot list RAG workspaces: status code %d", res.StatusCode)
-		return nil
-	}
-	var body struct {
-		Workspaces []struct {
-			WorkspaceID string `json:"workspace_id"`
-		} `json:"workspaces"`
-	}
-	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
-		logger.Warnf("cannot decode RAG workspaces: %s", err)
-		return nil
-	}
-	existingIDs := make([]string, 0, len(body.Workspaces))
-	for _, ws := range body.Workspaces {
-		existingIDs = append(existingIDs, ws.WorkspaceID)
-	}
-	pruneMissingWorkspaces(kb.folders, existingIDs)
-	if len(kb.folders) == 0 {
-		return nil
-	}
-	return kb
+	return true, nil
 }
 
-// pruneMissingWorkspaces removes from folders the knowledge-base folders
-// whose workspace does not exist (yet) in openRAG: uploads and reconciliation
-// may only reference existing workspaces (the workspace is created, lazily,
-// by ensureWorkspace on the first chat query).
-func pruneMissingWorkspaces(folders map[string]string, existingIDs []string) {
-	existing := make(map[string]bool, len(existingIDs))
-	for _, id := range existingIDs {
-		existing[id] = true
-	}
-	for dirID := range folders {
-		if !existing[dirID] {
-			delete(folders, dirID)
-		}
-	}
-}
-
-// parentPath resolves and caches the full path of a directory. The boolean
-// return value is false when the path could not be resolved (e.g. a
-// transient VFS/CouchDB error): callers must treat that as "unknown", never
-// as "no ancestors" (which would incorrectly detach the file from every
-// knowledge-base workspace).
-func (kb *kbContext) parentPath(inst *instance.Instance, dirID string) (string, bool) {
-	if p, ok := kb.dirPaths[dirID]; ok {
-		return p, true
-	}
-	dir, err := inst.VFS().DirByID(dirID)
-	if err != nil {
-		return "", false
-	}
-	kb.dirPaths[dirID] = dir.Fullpath
-	return dir.Fullpath, true
-}
-
-// reconcileDirChildren aligns the workspace membership of the direct file
-// children of a directory whose doc changed (typically a move or a rename).
-// Direct children are enough: a moved or renamed subtree puts every
-// descendant directory in the changes feed, so each affected file is seen as
-// the direct child of one of the changed directories. Best-effort: errors
-// are logged.
-func reconcileDirChildren(inst *instance.Instance, logger logger.Logger, kb *kbContext, dirID, dirPath string) {
-	if kb.empty() {
-		return
-	}
-	// The changes feed carries the directory's fresh path: seed the cache so
-	// the per-file reconciliation does not fetch it again.
-	kb.dirPaths[dirID] = dirPath
-	iter := inst.VFS().DirIterator(&vfs.DirDoc{DocID: dirID, Fullpath: dirPath}, nil)
-	for {
-		_, file, err := iter.Next()
-		if errors.Is(err, vfs.ErrIteratorDone) {
-			return
-		}
-		if err != nil {
-			logger.Warnf("cannot list children of dir %s: %s", dirID, err)
-			return
-		}
-		if file == nil || file.Trashed {
-			continue
-		}
-		reconcileMembership(inst, logger, kb, file.DocID, dirID)
-	}
-}
-
-// reconcileMembership aligns one file's workspace membership with the
-// knowledge-base folders containing it. Best-effort: errors are logged.
-func reconcileMembership(inst *instance.Instance, logger logger.Logger, kb *kbContext, fileID, dirID string) {
-	if kb.empty() {
-		return
-	}
-	desired, ok := kb.desiredFor(inst, dirID)
-	if !ok {
-		logger.Warnf("cannot resolve parent path for file %s (dir %s): skipping workspace reconciliation", fileID, dirID)
-		return
-	}
-	reconcileMembershipHTTP(inst.RAGServer(), inst.Domain, fileID, desired, kb.folders, logger)
-}
-
-// reconcileMembershipHTTP is the instance-free part of reconcileMembership,
-// split out so the diff/add/remove behavior can be unit-tested against an
-// httptest server.
-func reconcileMembershipHTTP(server config.RAGServer, domain, fileID string, desired []string, known map[string]string, logger logger.Logger) {
-	res, err := callRAG(server, http.MethodGet, nil, fmt.Sprintf("/partition/%s/files/%s/workspaces", domain, url.PathEscape(fileID)), echo.MIMEApplicationJSON)
-	if err != nil {
-		logger.Warnf("workspace membership check failed for %s: %s", fileID, err)
-		return
-	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		logger.Warnf("workspace membership check failed for %s: status code %d", fileID, res.StatusCode)
-		return
-	}
-	var body struct {
-		WorkspaceIDs []string `json:"workspace_ids"`
-	}
-	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
-		logger.Warnf("workspace membership check failed for %s: %s", fileID, err)
-		return
-	}
-	// openRAG may host workspaces the stack does not manage: they must not
-	// lose this file just because they are absent from `desired`.
-	var actual []string
-	for _, id := range body.WorkspaceIDs {
-		if _, ok := known[id]; ok {
-			actual = append(actual, id)
-		}
-	}
-	toAdd, toRemove := diffMembership(desired, actual)
-	for _, ws := range toAdd {
-		status, err := postWorkspaceFiles(server, domain, ws, []string{fileID})
-		if err != nil {
-			logger.Warnf("workspace add failed for %s in %s: %s", fileID, ws, err)
-		} else if status >= 300 {
-			logger.Warnf("workspace add failed for %s in %s: status code %d", fileID, ws, status)
-		}
-	}
-	for _, ws := range toRemove {
-		r, err := callRAG(server, http.MethodDelete, nil, fmt.Sprintf("/partition/%s/workspaces/%s/files/%s", domain, url.PathEscape(ws), url.PathEscape(fileID)), echo.MIMEApplicationJSON)
-		if err != nil {
-			logger.Warnf("workspace remove failed for %s in %s: %s", fileID, ws, err)
-			continue
-		}
-		r.Body.Close()
-		// 404: the file is already absent from the workspace, fine.
-		if r.StatusCode >= 300 && r.StatusCode != http.StatusNotFound {
-			logger.Warnf("workspace remove failed for %s in %s: status code %d", fileID, ws, r.StatusCode)
-		}
-	}
-}
-
-// ensureWorkspace makes sure the openRAG workspace mirroring the knowledge
-// base folder exists, creating it and backfilling its membership from the
-// folder subtree when needed. An error means the query MUST NOT proceed
-// unscoped.
-func ensureWorkspace(inst *instance.Instance, logger logger.Logger, dirID string) error {
-	// Steady state: the workspace exists for every message but the first
-	// one. Check it outside any lock so the common path stays lock-free.
-	exists, err := workspaceExists(inst.RAGServer(), inst.Domain, dirID)
+// ensureWorkspaceExists creates the workspace (and the partition if needed)
+// when it is missing. No file is attached here: the indexing attaches them.
+func ensureWorkspaceExists(server config.RAGServer, domain, id, displayName string, logger logger.Logger) error {
+	exists, err := workspaceExists(server, domain, id)
 	if err != nil {
 		return err
 	}
 	if exists {
 		return nil
 	}
-	// Creation path: serialize the concurrent queries racing on the same
-	// folder (the rag-query worker runs several jobs in parallel): without
-	// this, two first-time chats could both create and backfill the
-	// workspace, and the rollback of a failed backfill could delete the
-	// workspace the other query just successfully ensured. The backfill of
-	// a large folder can outlive a plain lock's TTL, hence LongOperation,
-	// which keeps refreshing it. ensureWorkspaceHTTP re-checks existence
-	// under the lock, so the loser of the race is a no-op.
-	mu := config.Lock().LongOperation(inst, "rag-workspace/"+dirID)
-	if err := mu.Lock(); err != nil {
-		return err
-	}
-	defer mu.Unlock()
-	resolve := func() (string, []string, error) {
-		dir, err := inst.VFS().DirByID(dirID)
-		if err != nil {
-			return "", nil, fmt.Errorf("knowledge base folder %s: %w", dirID, err)
-		}
-		fileIDs, err := listFolderFileIDs(inst, dirID)
-		if err != nil {
-			return "", nil, err
-		}
-		return dir.DocName, fileIDs, nil
-	}
-	return ensureWorkspaceHTTP(inst.RAGServer(), inst.Domain, dirID, resolve, logger)
-}
-
-// ensureWorkspaceHTTP is the instance-free part of ensureWorkspace, split
-// out so the create/backfill/rollback behavior can be unit-tested against an
-// httptest server. `resolve` is a callback rather than precomputed values
-// because it must stay lazy: the workspace already exists for every message
-// but the first one, and resolving eagerly would make each of them pay a VFS
-// lookup and a full folder-subtree walk for nothing.
-func ensureWorkspaceHTTP(server config.RAGServer, domain, dirID string, resolve func() (displayName string, fileIDs []string, err error), logger logger.Logger) error {
-	exists, err := workspaceExists(server, domain, dirID)
-	if err != nil {
-		return err
-	}
-	if exists {
-		return nil
-	}
-
-	// The partition may not exist yet on a fresh instance (same pattern as
-	// the completion 404 path in Query).
 	createRAGPartition(server, domain, logger)
-
-	displayName, fileIDs, err := resolve()
-	if err != nil {
-		return err
-	}
-
-	createBody, err := json.Marshal(map[string]interface{}{
-		"workspace_id": dirID,
+	body, err := json.Marshal(map[string]interface{}{
+		"workspace_id": id,
 		"display_name": displayName,
 	})
 	if err != nil {
 		return err
 	}
-	createRes, err := callRAG(server, http.MethodPost, createBody, fmt.Sprintf("/partition/%s/workspaces", domain), echo.MIMEApplicationJSON)
+	res, err := callRAG(server, http.MethodPost, body, fmt.Sprintf("/partition/%s/workspaces", domain), echo.MIMEApplicationJSON)
 	if err != nil {
-		return err
-	}
-	createRes.Body.Close()
-	if !createdOrExists(createRes.StatusCode) {
-		return fmt.Errorf("workspace creation status code: %d", createRes.StatusCode)
-	}
-
-	for chunk := range slices.Chunk(fileIDs, workspaceBackfillChunkSize) {
-		if err := backfillChunk(server, domain, dirID, chunk, logger); err != nil {
-			// The workspace was just created but is incomplete, and a later
-			// ensureWorkspace call would see it exists (GET 200) and never
-			// retry the backfill: delete it so the next call starts over.
-			deleteWorkspace(server, domain, dirID, logger)
-			return err
-		}
-	}
-	return nil
-}
-
-// deleteWorkspace best-effort deletes a workspace whose membership backfill
-// failed. If the deletion itself fails, the workspace stays incomplete until
-// an operator or a future ensure path cleans it up: log loudly.
-func deleteWorkspace(server config.RAGServer, domain, dirID string, logger logger.Logger) {
-	res, err := callRAG(server, http.MethodDelete, nil, fmt.Sprintf("/partition/%s/workspaces/%s", domain, url.PathEscape(dirID)), echo.MIMEApplicationJSON)
-	if err != nil {
-		logger.Errorf("cannot rollback incomplete RAG workspace %s: %s", dirID, err)
-		return
+		return retryable(err)
 	}
 	res.Body.Close()
-	if res.StatusCode >= 300 && res.StatusCode != http.StatusNotFound {
-		logger.Errorf("cannot rollback incomplete RAG workspace %s: status code %d", dirID, res.StatusCode)
-	}
+	return statusError("POST workspace", res.StatusCode, http.StatusConflict)
 }
 
-// workspaceExists tells whether the workspace exists on the openRAG server.
-func workspaceExists(server config.RAGServer, domain, dirID string) (bool, error) {
-	res, err := callRAG(server, http.MethodGet, nil, fmt.Sprintf("/partition/%s/workspaces/%s", domain, url.PathEscape(dirID)), echo.MIMEApplicationJSON)
+// deleteWorkspace removes the workspace from openRAG. A 404 is fine.
+func deleteWorkspace(server config.RAGServer, domain, id string) error {
+	res, err := callRAG(server, http.MethodDelete, nil, fmt.Sprintf("/partition/%s/workspaces/%s", domain, url.PathEscape(id)), echo.MIMEApplicationJSON)
 	if err != nil {
-		return false, err
+		return retryable(err)
 	}
 	res.Body.Close()
-	switch res.StatusCode {
-	case http.StatusOK:
-		return true, nil
-	case http.StatusNotFound:
-		return false, nil
-	default:
-		return false, fmt.Errorf("workspace check status code: %d", res.StatusCode)
-	}
+	return statusError("DELETE workspace", res.StatusCode, http.StatusNotFound)
 }
 
-// postWorkspaceFiles posts a batch of file ids to a workspace's /files
-// endpoint and returns the response status code.
-func postWorkspaceFiles(server config.RAGServer, domain, workspaceID string, ids []string) (int, error) {
-	body, err := json.Marshal(map[string]interface{}{"file_ids": ids})
-	if err != nil {
-		return 0, err
-	}
-	path := fmt.Sprintf("/partition/%s/workspaces/%s/files", domain, url.PathEscape(workspaceID))
-	res, err := callRAG(server, http.MethodPost, body, path, echo.MIMEApplicationJSON)
-	if err != nil {
-		return 0, err
-	}
-	res.Body.Close()
-	return res.StatusCode, nil
-}
-
-// backfillChunk posts one backfill chunk of file ids to the workspace.
-// openRAG's endpoint is all-or-nothing: ANY unknown file id in the chunk
-// yields a 404 and adds NONE of the chunk's ids, even the ones that are
-// indexed. When that happens, the chunk's ids are retried one by one so the
-// indexable files are still attached; a per-id 404 is expected for
-// non-indexed files (e.g. an image skipped by the indexer's class flags) and
-// only logged. Any other non-2xx status (chunked or per-id) is systemic and
-// is an ensure failure, so the query does not proceed with a silently
-// incomplete workspace.
-func backfillChunk(server config.RAGServer, domain, dirID string, ids []string, logger logger.Logger) error {
-	status, err := postWorkspaceFiles(server, domain, dirID, ids)
-	if err != nil {
-		return err
-	}
-	if status != http.StatusNotFound {
-		// Only a 404 can be a benign per-file condition. Anything else
-		// non-2xx (401/403 auth or permission problems, 5xx failures…) is
-		// systemic: fail the ensure rather than leave a silently incomplete
-		// workspace behind.
-		if status >= 300 {
-			return fmt.Errorf("workspace backfill status code: %d", status)
-		}
-		return nil
-	}
-
-	// A 404 can mean "some file id in the chunk is not indexed" (benign) or
-	// "the workspace itself is gone" (the ensure MUST fail so the query does
-	// not proceed scoped to a nonexistent workspace): disambiguate before
-	// falling back to per-id retries.
-	exists, err := workspaceExists(server, domain, dirID)
+// checkWorkspace is the chat-time check: the workspace must already exist,
+// created by the rag-index job when it reconciled the folder. It takes a
+// workspace id (see workspaceIDForDir), not a folder id.
+func checkWorkspace(inst *instance.Instance, workspaceID string) error {
+	exists, err := workspaceExists(inst.RAGServer(), inst.Domain, workspaceID)
 	if err != nil {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("workspace %s disappeared during backfill", dirID)
-	}
-
-	// At least one id in the chunk is unknown to openRAG: retry one by one.
-	for _, id := range ids {
-		idStatus, err := postWorkspaceFiles(server, domain, dirID, []string{id})
-		if err != nil {
-			return err
-		}
-		switch {
-		case idStatus == http.StatusNotFound:
-			logger.Debugf("workspace backfill skipped file %s (not indexed)", id)
-		case idStatus >= 300:
-			return fmt.Errorf("workspace backfill status code: %d", idStatus)
-		}
+		return ErrWorkspaceMissing
 	}
 	return nil
-}
-
-// listFolderFileIDs walks the folder subtree and returns the ids of the
-// (non-trashed) files it contains.
-func listFolderFileIDs(inst *instance.Instance, dirID string) ([]string, error) {
-	var ids []string
-	fs := inst.VFS()
-	err := vfs.WalkByID(fs, dirID, func(_ string, _ *vfs.DirDoc, file *vfs.FileDoc, err error) error {
-		if err != nil {
-			return err
-		}
-		if file != nil && !file.Trashed {
-			ids = append(ids, file.DocID)
-		}
-		return nil
-	})
-	return ids, err
-}
-
-// diffMembership compares the desired and actual workspace memberships of a
-// file and returns what must be added and removed.
-func diffMembership(desired, actual []string) (toAdd, toRemove []string) {
-	actualSet := make(map[string]bool, len(actual))
-	for _, id := range actual {
-		actualSet[id] = true
-	}
-	desiredSet := make(map[string]bool, len(desired))
-	for _, id := range desired {
-		desiredSet[id] = true
-		if !actualSet[id] {
-			toAdd = append(toAdd, id)
-		}
-	}
-	for _, id := range actual {
-		if !desiredSet[id] {
-			toRemove = append(toRemove, id)
-		}
-	}
-	return toAdd, toRemove
 }

--- a/model/rag/workspace_http_test.go
+++ b/model/rag/workspace_http_test.go
@@ -1,455 +1,12 @@
 package rag
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
-	"net/http/httptest"
-	"sync"
 	"testing"
 
-	"github.com/cozy/cozy-stack/pkg/config/config"
-	"github.com/cozy/cozy-stack/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// recordedRequest captures one request observed by a test httptest server.
-type recordedRequest struct {
-	Method string
-	Path   string
-	Body   []byte
-}
-
-// requestRecorder is a small thread-safe helper to record and assert on the
-// HTTP requests received by an httptest server.
-type requestRecorder struct {
-	mu       sync.Mutex
-	requests []recordedRequest
-}
-
-func (r *requestRecorder) record(req *http.Request) {
-	body, _ := io.ReadAll(req.Body)
-	req.Body.Close()
-	// Restore the body so the test's own handler can still read it.
-	req.Body = io.NopCloser(bytes.NewReader(body))
-	rr := recordedRequest{Method: req.Method, Path: req.URL.Path, Body: body}
-	r.mu.Lock()
-	r.requests = append(r.requests, rr)
-	r.mu.Unlock()
-}
-
-func (r *requestRecorder) all() []recordedRequest {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	out := make([]recordedRequest, len(r.requests))
-	copy(out, r.requests)
-	return out
-}
-
-func (r *requestRecorder) countPath(path string) int {
-	n := 0
-	for _, rr := range r.all() {
-		if rr.Path == path {
-			n++
-		}
-	}
-	return n
-}
-
-func testLogger() logger.Logger {
-	return logger.WithNamespace("rag-test")
-}
-
-func newRAGTestServer(t *testing.T, handler http.HandlerFunc) (config.RAGServer, *requestRecorder) {
-	t.Helper()
-	rec := &requestRecorder{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		rec.record(req)
-		handler(w, req)
-	}))
-	t.Cleanup(srv.Close)
-	server := config.RAGServer{URL: srv.URL, APIKey: "test-key"}
-	return server, rec
-}
-
-func decodeFileIDs(t *testing.T, body []byte) []string {
-	t.Helper()
-	var payload struct {
-		FileIDs []string `json:"file_ids"`
-	}
-	require.NoError(t, json.Unmarshal(body, &payload))
-	return payload.FileIDs
-}
-
-// --- ensureWorkspaceHTTP ---------------------------------------------------
-
-func TestEnsureWorkspaceHTTP(t *testing.T) {
-	t.Run("workspace already exists: GET 200 short-circuits", func(t *testing.T) {
-		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
-			assert.Equal(t, http.MethodGet, req.Method)
-			assert.Equal(t, "/partition/example.mycozy.cloud/workspaces/folder1", req.URL.Path)
-			w.WriteHeader(http.StatusOK)
-		})
-
-		resolve := func() (string, []string, error) { return "My folder", []string{"file1"}, nil }
-		err := ensureWorkspaceHTTP(server, "example.mycozy.cloud", "folder1", resolve, testLogger())
-		require.NoError(t, err)
-		assert.Len(t, rec.all(), 1, "no further calls once the workspace is known to exist")
-	})
-
-	t.Run("workspace already exists: resolver is not called (laziness)", func(t *testing.T) {
-		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})
-
-		resolverCalled := false
-		resolve := func() (string, []string, error) {
-			resolverCalled = true
-			return "", nil, fmt.Errorf("resolver must not be called on GET 200")
-		}
-		err := ensureWorkspaceHTTP(server, "example.mycozy.cloud", "folder1", resolve, testLogger())
-		require.NoError(t, err)
-		assert.False(t, resolverCalled, "resolver must stay lazy on the GET-200 short-circuit")
-		assert.Len(t, rec.all(), 1)
-	})
-
-	t.Run("workspace missing: creates partition, workspace, and backfills", func(t *testing.T) {
-		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
-			switch {
-			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
-				w.WriteHeader(http.StatusNotFound)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
-				w.WriteHeader(http.StatusCreated)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
-				body, _ := io.ReadAll(req.Body)
-				var payload map[string]string
-				require.NoError(t, json.Unmarshal(body, &payload))
-				assert.Equal(t, "folder1", payload["workspace_id"])
-				assert.Equal(t, "My folder", payload["display_name"])
-				w.WriteHeader(http.StatusCreated)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
-				body, _ := io.ReadAll(req.Body)
-				assert.Equal(t, []string{"file1", "file2"}, decodeFileIDs(t, body))
-				w.WriteHeader(http.StatusOK)
-			default:
-				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
-			}
-		})
-
-		resolve := func() (string, []string, error) { return "My folder", []string{"file1", "file2"}, nil }
-		err := ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger())
-		require.NoError(t, err)
-		assert.Equal(t, 1, rec.countPath("/partition/dom/workspaces/folder1"))
-		assert.Equal(t, 1, rec.countPath("/partition/dom"))
-		assert.Equal(t, 1, rec.countPath("/partition/dom/workspaces"))
-		assert.Equal(t, 1, rec.countPath("/partition/dom/workspaces/folder1/files"))
-	})
-
-	t.Run("workspace create 409 is tolerated and backfill still runs", func(t *testing.T) {
-		server, _ := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
-			switch {
-			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
-				w.WriteHeader(http.StatusNotFound)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
-				w.WriteHeader(http.StatusConflict)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
-				w.WriteHeader(http.StatusConflict)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
-				w.WriteHeader(http.StatusOK)
-			default:
-				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
-			}
-		})
-
-		resolve := func() (string, []string, error) { return "My folder", []string{"file1"}, nil }
-		err := ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger())
-		require.NoError(t, err)
-	})
-
-	t.Run("backfill chunk 404 falls back to per-id retries (CRITICAL fix)", func(t *testing.T) {
-		// openRAG's /files endpoint is all-or-nothing: any unknown id in the
-		// batch 404s and adds NONE of the ids, even the indexable ones. A
-		// single-id post must be attempted for every id in the chunk so
-		// indexable files still get attached.
-		var mu sync.Mutex
-		workspaceExists := false
-		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
-			mu.Lock()
-			defer mu.Unlock()
-			switch {
-			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
-				// 404 before creation; 200 for the disambiguation check that
-				// follows the chunk 404.
-				if workspaceExists {
-					w.WriteHeader(http.StatusOK)
-				} else {
-					w.WriteHeader(http.StatusNotFound)
-				}
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
-				w.WriteHeader(http.StatusCreated)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
-				workspaceExists = true
-				w.WriteHeader(http.StatusCreated)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
-				body, _ := io.ReadAll(req.Body)
-				ids := decodeFileIDs(t, body)
-				if len(ids) > 1 {
-					// batch contains the non-indexable "image1": reject all.
-					w.WriteHeader(http.StatusNotFound)
-					return
-				}
-				if ids[0] == "image1" {
-					w.WriteHeader(http.StatusNotFound)
-					return
-				}
-				w.WriteHeader(http.StatusOK)
-			default:
-				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
-			}
-		})
-
-		resolve := func() (string, []string, error) { return "My folder", []string{"file1", "image1", "file2"}, nil }
-		err := ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger())
-		require.NoError(t, err)
-
-		var singleIDBodies [][]string
-		for _, rr := range rec.all() {
-			if rr.Method == http.MethodPost && rr.Path == "/partition/dom/workspaces/folder1/files" {
-				ids := decodeFileIDs(t, rr.Body)
-				if len(ids) == 1 {
-					singleIDBodies = append(singleIDBodies, ids)
-				}
-			}
-		}
-		// one retry per id in the rejected chunk
-		assert.ElementsMatch(t, [][]string{{"file1"}, {"image1"}, {"file2"}}, singleIDBodies)
-	})
-
-	t.Run("backfill 403 is an ensure failure and rolls the workspace back", func(t *testing.T) {
-		// A 4xx other than 404 (e.g. an auth or permission problem) is
-		// systemic: succeeding would leave a silently incomplete workspace.
-		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
-			switch {
-			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
-				w.WriteHeader(http.StatusNotFound)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
-				w.WriteHeader(http.StatusCreated)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
-				w.WriteHeader(http.StatusCreated)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
-				w.WriteHeader(http.StatusForbidden)
-			case req.Method == http.MethodDelete && req.URL.Path == "/partition/dom/workspaces/folder1":
-				w.WriteHeader(http.StatusOK)
-			default:
-				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
-			}
-		})
-
-		resolve := func() (string, []string, error) { return "My folder", []string{"file1"}, nil }
-		err := ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger())
-		require.Error(t, err)
-		var deletes int
-		for _, rr := range rec.all() {
-			if rr.Method == http.MethodDelete && rr.Path == "/partition/dom/workspaces/folder1" {
-				deletes++
-			}
-		}
-		assert.Equal(t, 1, deletes)
-	})
-
-	t.Run("backfill 404 with a vanished workspace is an ensure failure", func(t *testing.T) {
-		// A chunk 404 normally means "some file id is not indexed" and is
-		// retried per id. But when the workspace itself is gone (e.g. deleted
-		// concurrently), the ensure must fail so the query does not proceed
-		// scoped to a nonexistent workspace.
-		var mu sync.Mutex
-		created := false
-		server, _ := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
-			mu.Lock()
-			defer mu.Unlock()
-			switch {
-			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
-				// 404 on the initial check AND on the post-chunk-404
-				// disambiguation check: the workspace vanished after its
-				// creation was acknowledged.
-				w.WriteHeader(http.StatusNotFound)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
-				w.WriteHeader(http.StatusCreated)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
-				created = true
-				w.WriteHeader(http.StatusCreated)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
-				w.WriteHeader(http.StatusNotFound)
-			case req.Method == http.MethodDelete && req.URL.Path == "/partition/dom/workspaces/folder1":
-				// rollback of the failed ensure
-				w.WriteHeader(http.StatusNotFound)
-			default:
-				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
-			}
-		})
-
-		resolve := func() (string, []string, error) { return "My folder", []string{"file1"}, nil }
-		err := ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger())
-		require.Error(t, err)
-		mu.Lock()
-		assert.True(t, created)
-		mu.Unlock()
-	})
-
-	t.Run("backfill 5xx is an ensure failure and rolls the workspace back", func(t *testing.T) {
-		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
-			switch {
-			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
-				w.WriteHeader(http.StatusNotFound)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
-				w.WriteHeader(http.StatusCreated)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
-				w.WriteHeader(http.StatusCreated)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
-				w.WriteHeader(http.StatusInternalServerError)
-			case req.Method == http.MethodDelete && req.URL.Path == "/partition/dom/workspaces/folder1":
-				w.WriteHeader(http.StatusOK)
-			default:
-				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
-			}
-		})
-
-		resolve := func() (string, []string, error) { return "My folder", []string{"file1"}, nil }
-		err := ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger())
-		require.Error(t, err)
-
-		var deletes int
-		for _, rr := range rec.all() {
-			if rr.Method == http.MethodDelete && rr.Path == "/partition/dom/workspaces/folder1" {
-				deletes++
-			}
-		}
-		assert.Equal(t, 1, deletes, "the incomplete workspace must be deleted so a later ensure retries the backfill")
-	})
-
-	t.Run("failed backfill is retried from scratch on the next ensure", func(t *testing.T) {
-		// First ensure: the backfill 5xx-fails, the workspace is rolled back.
-		// Second ensure: the GET must see 404 again (not 200) and the whole
-		// create+backfill sequence must rerun and succeed.
-		var mu sync.Mutex
-		workspaceExists := false
-		failBackfill := true
-		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
-			mu.Lock()
-			defer mu.Unlock()
-			switch {
-			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/workspaces/folder1":
-				if workspaceExists {
-					w.WriteHeader(http.StatusOK)
-				} else {
-					w.WriteHeader(http.StatusNotFound)
-				}
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom":
-				w.WriteHeader(http.StatusCreated)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
-				workspaceExists = true
-				w.WriteHeader(http.StatusCreated)
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/folder1/files":
-				if failBackfill {
-					failBackfill = false
-					w.WriteHeader(http.StatusInternalServerError)
-				} else {
-					w.WriteHeader(http.StatusOK)
-				}
-			case req.Method == http.MethodDelete && req.URL.Path == "/partition/dom/workspaces/folder1":
-				workspaceExists = false
-				w.WriteHeader(http.StatusOK)
-			default:
-				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
-			}
-		})
-
-		resolve := func() (string, []string, error) { return "My folder", []string{"file1"}, nil }
-		require.Error(t, ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger()))
-		require.NoError(t, ensureWorkspaceHTTP(server, "dom", "folder1", resolve, testLogger()))
-
-		assert.Equal(t, 2, rec.countPath("/partition/dom/workspaces"),
-			"the workspace must be re-created by the second ensure")
-		assert.Equal(t, 2, rec.countPath("/partition/dom/workspaces/folder1/files"),
-			"the backfill must rerun after the rollback")
-	})
-}
-
-// --- reconcileMembershipHTTP -----------------------------------------------
-
-func TestReconcileMembershipHTTP(t *testing.T) {
-	t.Run("adds and removes exactly per diff", func(t *testing.T) {
-		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
-			switch {
-			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/files/file1/workspaces":
-				_ = json.NewEncoder(w).Encode(map[string]interface{}{
-					"workspace_ids": []string{"ws-remove", "ws-keep"},
-				})
-			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces/ws-add/files":
-				body, _ := io.ReadAll(req.Body)
-				assert.Equal(t, []string{"file1"}, decodeFileIDs(t, body))
-				w.WriteHeader(http.StatusOK)
-			case req.Method == http.MethodDelete && req.URL.Path == "/partition/dom/workspaces/ws-remove/files/file1":
-				w.WriteHeader(http.StatusOK)
-			default:
-				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
-			}
-		})
-
-		known := map[string]string{"ws-add": "/a", "ws-keep": "/b", "ws-remove": "/c"}
-		reconcileMembershipHTTP(server, "dom", "file1", []string{"ws-keep", "ws-add"}, known, testLogger())
-
-		assert.Equal(t, 1, rec.countPath("/partition/dom/workspaces/ws-add/files"))
-		assert.Equal(t, 1, rec.countPath("/partition/dom/workspaces/ws-remove/files/file1"))
-		assert.Equal(t, 0, rec.countPath("/partition/dom/workspaces/ws-keep/files"))
-	})
-
-	t.Run("foreign workspace in actual membership is never deleted", func(t *testing.T) {
-		// The file's actual openRAG membership includes a workspace id the
-		// stack does not manage (not in `known`). It must be left alone: no
-		// DELETE call for it, even though it is absent from `desired`.
-		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
-			switch {
-			case req.Method == http.MethodGet && req.URL.Path == "/partition/dom/files/file1/workspaces":
-				_ = json.NewEncoder(w).Encode(map[string]interface{}{
-					"workspace_ids": []string{"ws-keep", "ws-foreign"},
-				})
-			case req.Method == http.MethodDelete:
-				t.Fatalf("unexpected DELETE for foreign workspace: %s", req.URL.Path)
-			default:
-				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
-			}
-		})
-
-		known := map[string]string{"ws-keep": "/b"}
-		reconcileMembershipHTTP(server, "dom", "file1", []string{"ws-keep"}, known, testLogger())
-
-		for _, rr := range rec.all() {
-			assert.NotEqual(t, http.MethodDelete, rr.Method, "no delete should be issued for a foreign workspace")
-		}
-	})
-
-	t.Run("GET failure causes no mutations", func(t *testing.T) {
-		server, rec := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-		})
-
-		known := map[string]string{"ws-add": "/a"}
-		reconcileMembershipHTTP(server, "dom", "file1", []string{"ws-add"}, known, testLogger())
-
-		assert.Len(t, rec.all(), 1, "only the failed GET, no add/remove calls")
-	})
-}
-
-func TestNilKBContextIsEmpty(t *testing.T) {
-	// loadKBContext returns nil on any error or when no assistant declares a
-	// knowledge base: reconcileMembership relies on empty() to gate that.
-	var kb *kbContext
-	assert.True(t, kb.empty())
-}
 
 func TestDirIDEscaping(t *testing.T) {
 	// Folder ids are arbitrary CouchDB ids (UUIDs, fixed ids like the Drive
@@ -463,4 +20,71 @@ func TestDirIDEscaping(t *testing.T) {
 	exists, err := workspaceExists(server, "dom", "kb/../1")
 	require.NoError(t, err)
 	assert.True(t, exists)
+}
+
+func TestCheckWorkspaceMissing(t *testing.T) {
+	fake := NewFakeOpenRAG(t)
+	exists, err := workspaceExists(fake.Server, "dom", "kb")
+	require.NoError(t, err)
+	assert.False(t, exists)
+	fake.AddWorkspace("kb")
+	exists, err = workspaceExists(fake.Server, "dom", "kb")
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestEnsureWorkspaceExists(t *testing.T) {
+	t.Run("existing workspace: a single GET", func(t *testing.T) {
+		fake := NewFakeOpenRAG(t)
+		fake.AddWorkspace("kb")
+		require.NoError(t, ensureWorkspaceExists(fake.Server, "dom", "kb", "Docs", TestingLogger()))
+		assert.Len(t, fake.Rec.All(), 1)
+	})
+
+	t.Run("missing workspace: partition and workspace are created", func(t *testing.T) {
+		fake := NewFakeOpenRAG(t)
+		require.NoError(t, ensureWorkspaceExists(fake.Server, "dom", "kb", "Docs", TestingLogger()))
+		assert.True(t, fake.HasWorkspace("kb"))
+		assert.Equal(t, 1, fake.Rec.Count(http.MethodPost, "/partition/dom"))
+		reqs := fake.Rec.All()
+		last := reqs[len(reqs)-1]
+		assert.Equal(t, "/partition/dom/workspaces", last.Path)
+		assert.Contains(t, string(last.Body), `"display_name":"Docs"`)
+		assert.Contains(t, string(last.Body), `"workspace_id":"kb"`)
+	})
+
+	t.Run("409 on creation is tolerated", func(t *testing.T) {
+		server, _ := newRAGTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+			switch {
+			case req.Method == http.MethodGet:
+				w.WriteHeader(http.StatusNotFound)
+			case req.Method == http.MethodPost && req.URL.Path == "/partition/dom/workspaces":
+				w.WriteHeader(http.StatusConflict)
+			default:
+				w.WriteHeader(http.StatusCreated)
+			}
+		})
+		require.NoError(t, ensureWorkspaceExists(server, "dom", "kb", "Docs", TestingLogger()))
+	})
+
+	t.Run("5xx on creation is a retryable error", func(t *testing.T) {
+		fake := NewFakeOpenRAG(t)
+		fake.Fail = func(method, path string) int {
+			if method == http.MethodPost && path == "/partition/dom/workspaces" {
+				return 500
+			}
+			return 0
+		}
+		err := ensureWorkspaceExists(fake.Server, "dom", "kb", "Docs", TestingLogger())
+		require.Error(t, err)
+		assert.True(t, isRetryable(err))
+	})
+}
+
+func TestDeleteWorkspace(t *testing.T) {
+	fake := NewFakeOpenRAG(t)
+	fake.AddWorkspace("kb")
+	require.NoError(t, deleteWorkspace(fake.Server, "dom", "kb"))
+	assert.False(t, fake.HasWorkspace("kb"))
+	require.NoError(t, deleteWorkspace(fake.Server, "dom", "kb"), "404 is tolerated")
 }

--- a/model/rag/workspace_test.go
+++ b/model/rag/workspace_test.go
@@ -1,9 +1,10 @@
 package rag
 
 import (
+	"strings"
 	"testing"
 
-	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/cozy/cozy-stack/pkg/consts"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,57 +14,62 @@ func TestKnowledgeBaseDirID(t *testing.T) {
 			{Doctype: "com.linagora.email", DirID: "nope"},
 			{Doctype: "io.cozy.files", DirID: "folder-1"},
 		}}
-		assert.Equal(t, "folder-1", a.knowledgeBaseDirID(testLogger()))
+		assert.Equal(t, "folder-1", a.knowledgeBaseDirID(TestingLogger()))
 	})
 	t.Run("returns empty without knowledge base", func(t *testing.T) {
-		assert.Equal(t, "", (&chatAssistant{}).knowledgeBaseDirID(testLogger()))
-		assert.Equal(t, "", (*chatAssistant)(nil).knowledgeBaseDirID(testLogger()))
+		assert.Equal(t, "", (&chatAssistant{}).knowledgeBaseDirID(TestingLogger()))
+		assert.Equal(t, "", (*chatAssistant)(nil).knowledgeBaseDirID(TestingLogger()))
 	})
 	t.Run("only the first files entry is used, extras are ignored", func(t *testing.T) {
 		a := &chatAssistant{KnowledgeBase: []knowledgeBaseEntry{
 			{Doctype: "io.cozy.files", DirID: "folder-1"},
 			{Doctype: "io.cozy.files", DirID: "folder-2"},
 		}}
-		assert.Equal(t, "folder-1", a.knowledgeBaseDirID(testLogger()))
+		assert.Equal(t, "folder-1", a.knowledgeBaseDirID(TestingLogger()))
 	})
 }
 
-func TestPruneMissingWorkspaces(t *testing.T) {
-	folders := map[string]string{
-		"kb1": "/Perso/HR",
-		"kb2": "/Projects",
-	}
-	// kb2's workspace does not exist in openRAG: it must never be desired,
-	// so it is pruned from the folder set.
-	pruneMissingWorkspaces(folders, []string{"kb1", "ws-foreign"})
-	assert.Equal(t, map[string]string{"kb1": "/Perso/HR"}, folders)
-
-	pruneMissingWorkspaces(folders, nil)
-	assert.Empty(t, folders)
-}
-
-func TestDiffMembership(t *testing.T) {
-	toAdd, toRemove := diffMembership([]string{"a", "b"}, []string{"b", "c"})
-	assert.Equal(t, []string{"a"}, toAdd)
-	assert.Equal(t, []string{"c"}, toRemove)
-
-	toAdd, toRemove = diffMembership(nil, nil)
-	assert.Empty(t, toAdd)
-	assert.Empty(t, toRemove)
-}
-
-func TestDesiredWorkspaces(t *testing.T) {
-	kb := kbContext{
-		// dirID -> folder path; loadKBContext only keeps folders whose
-		// workspace already exists in openRAG.
-		folders: map[string]string{
-			"kb1": "/Perso/HR",
-			"kb2": "/Projects",
-		},
-	}
-	assert.Equal(t, []string{"kb1"}, kb.desiredWorkspaces("/Perso/HR/contracts"))
-	assert.Equal(t, []string{"kb1"}, kb.desiredWorkspaces("/Perso/HR"))
-	assert.Empty(t, kb.desiredWorkspaces("/Perso/HRX")) // no false prefix match
-	assert.Empty(t, kb.desiredWorkspaces("/Elsewhere"))
-	assert.Empty(t, kb.desiredWorkspaces(vfs.TrashDirName+"/Perso/HR")) // trashed content
+func TestWorkspaceIDForDir(t *testing.T) {
+	t.Run("every well-known folder id becomes a valid workspace id", func(t *testing.T) {
+		// openRAG only accepts ^[A-Za-z0-9_-]+$ and answers 422 otherwise;
+		// the well-known folder ids are the only ones with dots.
+		assert.Equal(t, map[string]string{
+			consts.RootDirID:           "io-cozy-files-root-dir",
+			consts.TrashDirID:          "io-cozy-files-trash-dir",
+			consts.SharedWithMeDirID:   "io-cozy-files-shared-with-me-dir",
+			consts.NoLongerSharedDirID: "io-cozy-files-no-longer-shared-dir",
+			consts.SharedDrivesDirID:   "io-cozy-files-shared-drives-dir",
+		}, wellKnownWorkspaceIDs)
+		for dirID, workspaceID := range wellKnownWorkspaceIDs {
+			assert.Regexp(t, `^[A-Za-z0-9_-]+$`, workspaceID)
+			assert.Equal(t, strings.ReplaceAll(dirID, ".", "-"), workspaceID)
+			assert.Equal(t, workspaceID, workspaceIDForDir(dirID))
+		}
+		assert.Len(t, wellKnownDirIDs, len(wellKnownWorkspaceIDs), "the ids are mapped one to one")
+	})
+	t.Run("a folder id is its own workspace id", func(t *testing.T) {
+		assert.Equal(t, "2ce11217a0efbe69b18e5d81de178422", workspaceIDForDir("2ce11217a0efbe69b18e5d81de178422"))
+	})
+	t.Run("round trip", func(t *testing.T) {
+		dirIDs := []string{"2ce11217a0efbe69b18e5d81de178422"}
+		for dirID := range wellKnownWorkspaceIDs {
+			dirIDs = append(dirIDs, dirID)
+		}
+		for _, dirID := range dirIDs {
+			assert.Equal(t, dirID, dirIDForWorkspace(workspaceIDForDir(dirID)))
+		}
+		workspaceIDs := []string{"2ce11217a0efbe69b18e5d81de178422"}
+		for _, workspaceID := range wellKnownWorkspaceIDs {
+			workspaceIDs = append(workspaceIDs, workspaceID)
+		}
+		for _, ws := range workspaceIDs {
+			assert.Equal(t, ws, workspaceIDForDir(dirIDForWorkspace(ws)))
+		}
+	})
+	t.Run("slices keep their order", func(t *testing.T) {
+		assert.Equal(t, []string{"abc", rootWorkspaceID}, workspaceIDsForDirs([]string{"abc", consts.RootDirID}))
+		assert.Equal(t, []string{"abc", consts.RootDirID}, dirIDsForWorkspaces([]string{"abc", rootWorkspaceID}))
+		assert.Empty(t, workspaceIDsForDirs(nil))
+		assert.Empty(t, dirIDsForWorkspaces(nil))
+	})
 }

--- a/model/rag/workspaces.go
+++ b/model/rag/workspaces.go
@@ -1,0 +1,163 @@
+package rag
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"slices"
+
+	"github.com/cozy/cozy-stack/model/instance"
+	"github.com/cozy/cozy-stack/model/vfs"
+	"github.com/cozy/cozy-stack/pkg/config/config"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/cozy/cozy-stack/pkg/logger"
+	"github.com/labstack/echo/v4"
+)
+
+// rootWorkspaceName is the display name of the workspace of the root folder.
+const rootWorkspaceName = "Drive"
+
+// listWorkspaces returns the ids of the workspaces openRAG holds for the
+// instance: workspace ids, not folder ids (see workspaceIDForDir). A 404
+// means the partition does not exist yet (it is created with the first
+// workspace): the instance simply has no workspace. Every other failure is
+// retryable, so the caller keeps its checkpoint instead of diffing on a
+// partial view.
+func listWorkspaces(server config.RAGServer, domain string) ([]string, error) {
+	res, err := callRAG(server, http.MethodGet, nil, fmt.Sprintf("/partition/%s/workspaces", domain), echo.MIMEApplicationJSON)
+	if err != nil {
+		return nil, retryable(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if res.StatusCode >= 300 {
+		return nil, retryable(fmt.Errorf("GET workspaces status code: %d", res.StatusCode))
+	}
+	var body struct {
+		Workspaces []struct {
+			ID string `json:"workspace_id"`
+		} `json:"workspaces"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(body.Workspaces))
+	for _, ws := range body.Workspaces {
+		ids = append(ids, ws.ID)
+	}
+	return ids, nil
+}
+
+// workspaceDisplayName is the name openRAG shows for a folder's workspace.
+func workspaceDisplayName(dirID, fullpath string) string {
+	if dirID == consts.RootDirID {
+		return rootWorkspaceName
+	}
+	return path.Base(fullpath)
+}
+
+// reconcileWorkspaces aligns the openRAG workspaces of the partition with the
+// knowledge base folders. A folder without workspace gets one, and a
+// reconcile job is then pushed for its subtree; a workspace without folder
+// loses its files (deleted when no membership remains) and is deleted.
+// Creation failures are only logged (the next run retries); removal failures
+// are returned so the job reports them, the workspace staying for the next
+// run.
+//
+// pushReconcile is nil when the caller is itself the reconcile job of the
+// folder own: the invariant is then that such a job neither pushes reconcile
+// jobs, nor creates or removes any workspace but own. Creating another
+// folder's workspace would strand that folder: nothing pushes its reconcile
+// job any more, its files did not change so the feed carries nothing about
+// them, and checkWorkspace already reports it as indexed.
+func reconcileWorkspaces(inst *instance.Instance, logger logger.Logger, server config.RAGServer, sc *scopes, own string, pushReconcile func(dirID string) error) error {
+	existing, err := listWorkspaces(server, inst.Domain)
+	if err != nil {
+		return err
+	}
+	// The diff works on folder ids: what openRAG lists are workspace ids.
+	toCreate, toRemove := diffWorkspaces(sc.folders, dirIDsForWorkspaces(existing))
+	if pushReconcile == nil {
+		// A reconcile job only makes sure its own workspace is there, so its
+		// uploads do not 404; the other folders, and the removals, are left
+		// to a feed job.
+		toRemove = nil
+		toCreate = slices.DeleteFunc(toCreate, func(dirID string) bool { return dirID != own })
+	}
+	for _, dirID := range toCreate {
+		// The workspace first: the reconcile job uploads into it, and a
+		// creation that keeps failing (openRAG refusing the id, say) would
+		// otherwise have every run push a whole-subtree job for nothing.
+		workspaceID := workspaceIDForDir(dirID)
+		name := workspaceDisplayName(dirID, sc.folders[dirID])
+		if err := ensureWorkspaceExists(server, inst.Domain, workspaceID, name, logger); err != nil {
+			logger.Warnf("cannot create the workspace of folder %s: %s", dirID, err)
+			continue
+		}
+		if pushReconcile == nil {
+			continue
+		}
+		if err := pushReconcile(dirID); err != nil {
+			logger.Warnf("cannot push the reconcile job of folder %s: %s", dirID, err)
+			// Roll back: an empty workspace claims the folder is indexed
+			// (checkWorkspace succeeds) while nothing walks its subtree any
+			// more. Deleting it makes the next run retry both.
+			if err := deleteWorkspace(server, inst.Domain, workspaceID); err != nil {
+				logger.Warnf("cannot delete the workspace %s after a failed push: %s", workspaceID, err)
+			}
+		}
+	}
+	var errj error
+	for _, dirID := range toRemove {
+		if err := removeWorkspace(inst, logger, server, workspaceIDForDir(dirID)); err != nil {
+			logger.Warnf("cannot remove the workspace of folder %s: %s", dirID, err)
+			errj = errors.Join(errj, err)
+		}
+	}
+	return errj
+}
+
+// removeWorkspace detaches the live files of the folder from its workspace
+// (deleting from openRAG those that belong to no other workspace), then
+// deletes the workspace. It takes a workspace id; the folder it stands for
+// is resolved with dirIDForWorkspace. A folder gone from the VFS only loses
+// its workspace: its files were deleted through the changes feed.
+func removeWorkspace(inst *instance.Instance, logger logger.Logger, server config.RAGServer, workspaceID string) error {
+	dirID := dirIDForWorkspace(workspaceID)
+	dir, err := inst.VFS().DirByID(dirID)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		logger.Infof("workspace %s matches no folder: deleting it", workspaceID)
+	case err != nil:
+		return retryable(err)
+	default:
+		if err := detachFolderFiles(inst, logger, dir, workspaceID); err != nil {
+			return err
+		}
+	}
+	return deleteWorkspace(server, inst.Domain, workspaceID)
+}
+
+// detachFolderFiles detaches every live file of the folder's subtree from
+// the workspace, and reports the files that could not be.
+func detachFolderFiles(inst *instance.Instance, logger logger.Logger, dir *vfs.DirDoc, workspaceID string) error {
+	var errj error
+	err := vfs.WalkAlreadyLocked(inst.VFS(), dir, func(_ string, _ *vfs.DirDoc, file *vfs.FileDoc, err error) error {
+		if err != nil {
+			return err
+		}
+		if file == nil || file.Trashed {
+			return nil
+		}
+		if err := detachFile(inst, file.DocID, workspaceID, logger); err != nil {
+			errj = errors.Join(errj, err)
+		}
+		return nil
+	})
+	return errors.Join(err, errj)
+}

--- a/model/rag/workspaces_test.go
+++ b/model/rag/workspaces_test.go
@@ -1,0 +1,129 @@
+package rag_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/cozy/cozy-stack/model/rag"
+	"github.com/cozy/cozy-stack/pkg/consts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileWorkspacesCreatesAndRemoves(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	gone := r.mkdir("/Gone")
+	inGone := r.writeFile("/Gone/g.txt", "g")
+	r.fake.AddWorkspace(gone.DocID)
+	r.fake.AddWorkspace("orphan-of-destroyed-folder")
+	r.fake.AddFile(inGone.DocID, "x", gone.DocID)
+	r.addAssistant("KB assistant", kb.DocID)
+
+	var pushed []string
+	require.NoError(t, rag.ReconcileWorkspacesForTest(r.inst, kb.DocID, func(dirID string) error {
+		pushed = append(pushed, dirID)
+		return nil
+	}))
+
+	assert.True(t, r.fake.HasWorkspace(kb.DocID), "missing workspace created")
+	assert.Equal(t, []string{kb.DocID}, pushed, "reconcile job pushed for the new folder")
+	assert.False(t, r.fake.HasWorkspace(gone.DocID), "workspace without assistant removed")
+	assert.False(t, r.fake.HasWorkspace("orphan-of-destroyed-folder"), "unresolvable workspace removed too")
+	_, ok := r.fake.File(inGone.DocID)
+	assert.False(t, ok, "file of the removed workspace deleted (no membership left)")
+	assert.Equal(t, 1, r.fake.Rec.Count(http.MethodPost, "/partition/"+r.inst.Domain+"/workspaces"))
+}
+
+func TestReconcileWorkspacesRootDisplayName(t *testing.T) {
+	r := newRAGTest(t)
+	r.addAssistant("Everything", consts.RootDirID)
+	require.NoError(t, rag.ReconcileWorkspacesForTest(r.inst, consts.RootDirID, func(string) error { return nil }))
+	assert.True(t, r.fake.HasWorkspace(rag.RootWorkspaceID))
+	reqs := r.fake.Rec.All()
+	var body string
+	for _, req := range reqs {
+		if req.Method == http.MethodPost && req.Path == "/partition/"+r.inst.Domain+"/workspaces" {
+			body = string(req.Body)
+		}
+	}
+	assert.Contains(t, body, `"display_name":"Drive"`)
+	assert.Contains(t, body, `"workspace_id":"`+rag.RootWorkspaceID+`"`, "openRAG refuses an id with dots")
+}
+
+// TestReconcileWorkspacesRemovesStaleRootWorkspace checks the reverse
+// mapping: the whole-Drive workspace is resolved back to the root folder,
+// which no assistant uses any more, so it is removed with its files.
+func TestReconcileWorkspacesRemovesStaleRootWorkspace(t *testing.T) {
+	r := newRAGTest(t)
+	doc := r.writeFile("/top.txt", "top")
+	r.fake.AddWorkspace(rag.RootWorkspaceID)
+	r.fake.AddFile(doc.DocID, "x", rag.RootWorkspaceID)
+
+	require.NoError(t, rag.ReconcileWorkspacesForTest(r.inst, "", func(string) error { return nil }))
+
+	assert.False(t, r.fake.HasWorkspace(rag.RootWorkspaceID))
+	_, ok := r.fake.File(doc.DocID)
+	assert.False(t, ok, "the live files of the whole Drive were detached, then deleted")
+}
+
+// TestReconcileWorkspacesPushesAfterCreation pins the order: the reconcile
+// job is pushed only once its workspace exists on openRAG.
+func TestReconcileWorkspacesPushesAfterCreation(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	r.addAssistant("KB assistant", kb.DocID)
+
+	var existedOnPush bool
+	require.NoError(t, rag.ReconcileWorkspacesForTest(r.inst, "", func(dirID string) error {
+		existedOnPush = r.fake.HasWorkspace(kb.DocID)
+		return nil
+	}))
+	assert.True(t, existedOnPush, "the workspace exists before its reconcile job is pushed")
+}
+
+// TestReconcileWorkspacesNoPushWhenCreationFails: nothing to index into, no
+// job; the failure is logged, not returned, and the next run retries.
+func TestReconcileWorkspacesNoPushWhenCreationFails(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	r.addAssistant("KB assistant", kb.DocID)
+	r.fake.Fail = func(method, path string) int {
+		if method == http.MethodPost && path == "/partition/"+r.inst.Domain+"/workspaces" {
+			return http.StatusInternalServerError
+		}
+		return 0
+	}
+
+	var pushed []string
+	require.NoError(t, rag.ReconcileWorkspacesForTest(r.inst, "", func(dirID string) error {
+		pushed = append(pushed, dirID)
+		return nil
+	}))
+	assert.Empty(t, pushed)
+	assert.False(t, r.fake.HasWorkspace(kb.DocID))
+}
+
+// TestReconcileWorkspacesRollsBackOnPushFailure: an empty workspace without
+// its job would claim the folder is indexed, so it is deleted again.
+func TestReconcileWorkspacesRollsBackOnPushFailure(t *testing.T) {
+	r := newRAGTest(t)
+	kb := r.mkdir("/KB")
+	r.addAssistant("KB assistant", kb.DocID)
+
+	require.NoError(t, rag.ReconcileWorkspacesForTest(r.inst, "", func(string) error {
+		return errors.New("the job queue is unreachable")
+	}))
+	assert.False(t, r.fake.HasWorkspace(kb.DocID))
+	assert.Equal(t, 1, r.fake.Rec.Count(http.MethodDelete, "/partition/"+r.inst.Domain+"/workspaces/"+kb.DocID))
+
+	// The next run retries both.
+	var pushed []string
+	require.NoError(t, rag.ReconcileWorkspacesForTest(r.inst, "", func(dirID string) error {
+		pushed = append(pushed, dirID)
+		return nil
+	}))
+	assert.True(t, r.fake.HasWorkspace(kb.DocID))
+	assert.Equal(t, []string{kb.DocID}, pushed)
+}

--- a/web/instances/instances.go
+++ b/web/instances/instances.go
@@ -775,6 +775,10 @@ func Routes(router *echo.Group) {
 	router.GET("/:domain/swift-prefix", getSwiftBucketName)
 	router.GET("/:domain/sharings/:sharing-id/unxor/:doc-id", unxorID)
 	router.POST("/:domain/notifications", sendNotification)
+	router.POST("/:domain/rag/reset", ragReset)
+	router.POST("/:domain/rag/prune", ragPrune)
+	router.POST("/:domain/rag/purge", ragPurge)
+	router.POST("/:domain/rag/reconcile", ragReconcile)
 
 	// Config
 	router.POST("/redis", rebuildRedis)

--- a/web/instances/rag.go
+++ b/web/instances/rag.go
@@ -1,0 +1,65 @@
+package instances
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/cozy/cozy-stack/model/instance/lifecycle"
+	"github.com/cozy/cozy-stack/model/rag"
+	"github.com/labstack/echo/v4"
+)
+
+// ragReset drops the rag-index checkpoint and pushes a rag-index job.
+func ragReset(c echo.Context) error {
+	inst, err := lifecycle.GetInstance(c.Param("domain"))
+	if err != nil {
+		return err
+	}
+	if err := rag.Reset(inst); err != nil {
+		return err
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+// ragReconcile pushes reconcile jobs (one folder, or every knowledge base
+// folder).
+func ragReconcile(c echo.Context) error {
+	inst, err := lifecycle.GetInstance(c.Param("domain"))
+	if err != nil {
+		return err
+	}
+	n, err := rag.Reconcile(inst, c.QueryParam("dir_id"))
+	if errors.Is(err, rag.ErrUnknownFolder) {
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
+	}
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, echo.Map{"jobs": n})
+}
+
+// ragPrune deletes from openRAG what no knowledge base folder claims.
+func ragPrune(c echo.Context) error {
+	inst, err := lifecycle.GetInstance(c.Param("domain"))
+	if err != nil {
+		return err
+	}
+	res, err := rag.Prune(inst, inst.Logger().WithNamespace("rag"))
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, res)
+}
+
+// ragPurge deletes everything openRAG holds for the instance, and the
+// rag-index checkpoint.
+func ragPurge(c echo.Context) error {
+	inst, err := lifecycle.GetInstance(c.Param("domain"))
+	if err != nil {
+		return err
+	}
+	if err := rag.Purge(inst, inst.Logger().WithNamespace("rag")); err != nil {
+		return err
+	}
+	return c.NoContent(http.StatusNoContent)
+}

--- a/worker/rag/rag.go
+++ b/worker/rag/rag.go
@@ -12,8 +12,8 @@ func init() {
 	job.AddWorker(&job.WorkerConfig{
 		WorkerType:   "rag-index",
 		Concurrency:  runtime.NumCPU(),
-		MaxExecCount: 1,
-		Reserved:     true,
+		MaxExecCount: 3,
+		RetryDelay:   30 * time.Second,
 		Timeout:      15 * time.Minute,
 		WorkerFunc:   WorkerIndex,
 	})


### PR DESCRIPTION
## RAG indexing scoped by the assistants' knowledge bases

The `rag-index` worker now indexes the folders listed in the `knowledgeBase` of the `io.cozy.ai.chat.assistants` documents, and only them. The root folder (`io.cozy.files.root-dir`) means the whole Drive.

### How it works

- One job per instance, one lock, one checkpoint on the `io.cozy.files` changes feed. Two `@event` triggers wake it up, created by the app in charge of the assistants (the worker is no longer reserved): `io.cozy.files` with a 30s debounce, and `io.cozy.ai.chat.assistants` without debounce.
- Every knowledge base folder has its openRAG workspace, named after the folder id (well-known dotted ids are mapped, e.g. `io-cozy-files-root-dir`). At every run the worker reconciles the workspaces with the folders: a new folder gets its workspace then a job that walks its subtree; a folder no assistant uses any more loses its workspace and its files are detached.
- A file is indexed in the workspaces of every folder containing it, its memberships follow it when it moves, and it is deleted from openRAG when no folder contains it. The chat scopes its retrieval to the workspace of the assistant's folder.
- Uploads are decided from the md5 openRAG holds. Its two 409 are told apart: an id it already holds is re-uploaded with a PUT, a content it already indexed under another id is skipped for good (openRAG deduplicates by content per partition). Files the indexer refuses or whose content is missing from the storage are skipped; only transient errors are retried.

### Operator tools

Admin routes `POST /instances/:domain/rag/{reset,reconcile?dir_id=,prune,purge}`, documented in `docs/admin.md` and `docs/ai.md`. The CLI wrappers (`cozy-stack rag …`) come in a separate PR (`feat/rag-cli`).

### Tests

`model/rag` integration tests run against an in-memory fake of the openRAG API (workspaces, memberships, both 409s, pending uploads, content deduplication). Validated end to end on a local instance with the cozy-search and cozy-drive counterparts.
