### PR TITLE
feat(storage): add a per-instance operation barrier

### DIFF
--- a/pkg/storagebarrier/README.md
+++ b/pkg/storagebarrier/README.md
@@ -1,0 +1,95 @@
+# Per-instance storage barrier
+
+This package provides admission and draining for storage maintenance. It does
+not yet change HTTP handlers, workers, VFS implementations, or migration commands.
+Those integrations must establish the lifecycle below before a migration can
+claim a consistent source snapshot.
+
+## Operation lifecycle
+
+Use one `Service` backed by the stack's lock Redis. `New(nil)` is only suitable
+for a single-process stack; independent in-memory services do not coordinate.
+Every participant must use the same canonical instance key, including its
+CouchDB cluster and database prefix, and the same Redis database.
+
+1. Load the instance's persisted storage generation with its backend selection.
+2. Call `Enter(ctx, key, generation, nil)` before using that backend to write.
+3. Keep the returned permit until both the object write and the CouchDB index
+   update have finished. For uploads this includes the writer's `Close`, not
+   just `CreateFile` or receiving the request body.
+4. Close the permit on all completed/error paths and report release failures.
+
+A request or job can pass its live permit as the parent of nested storage
+operations. The last nested operation keeps its parent registration alive even
+if the outer request has returned. A closed parent cannot admit new nested work.
+Permits are local handles: never serialize or copy their values.
+
+`ErrBusy` means maintenance has stopped admission. HTTP/CLI clients should get a
+retryable response; jobs should remain queued or be deferred without exhausting
+their normal execution retries. `ErrStale` means the caller must reload its
+instance/backend, not retry using the same VFS handle.
+
+All storage mutations need coverage, including background jobs, admin/CLI
+requests, sharing writes to another instance, file versions, deletes, avatars,
+and direct index updates. Admission around HTTP traffic alone is insufficient.
+
+## Maintenance lifecycle
+
+1. Call `Block` to close admission and elect a single owner for the instance.
+2. Call `Wait` to drain already-admitted operations. Their nested work can
+   finish, while unrelated instances and concurrent ordinary writers remain
+   independent.
+3. Copy and verify using maintenance-owned storage handles, without entering
+   the barrier again. Calling ordinary admission here would reject the owner.
+4. Call `Check` before destructive steps or cutover. On any coordination error,
+   stop; do not switch backends or purge data.
+5. Persist the new backend and a monotonically increasing storage generation
+   together, then call `Open` with that generation to resume admission.
+
+`Open` checks ownership and requires zero outstanding operations atomically.
+An earlier generation is rejected, including a VFS handle from before a
+round-trip migration back to the original backend. `Cancel` is only for aborting
+before backend/content changes; it reopens admission without changing generation
+and can be called while operations are still draining.
+
+A failed or ambiguous backend update must leave admission closed. The package
+does not make Redis and CouchDB one transaction and does not fence direct writes
+at either storage server. Its safety depends on every writer participating and
+the coordinator stopping on errors. Checks alone cannot protect against an
+operator concurrently resetting coordination state.
+
+## Failure and recovery
+
+Permits and owner registrations have **no TTL**. Expiring a registration could
+mistake a paused writer for a completed upload. A crashed writer, owner, or an
+ambiguous Redis reply can therefore require manual recovery instead of automatic
+availability. Cancelling `Wait` does not release other processes' permits.
+
+Redis must retain these keys: use durable storage and a non-evicting policy. Do
+not flush the lock database, delete barrier keys, restore stale snapshots, or
+switch Redis endpoints while stack processes are operating. Losing registrations
+can hide active writers; generation checks are not a substitute for durability.
+The in-memory fallback must not be used across multiple stack processes.
+
+For recovery, first stop and confirm termination of every process that can write
+to the affected instance, including external jobs. Inspect the authoritative
+backend/generation and resolve any uncertain cutover before repairing only the
+affected `storage-barrier:<canonical-instance-key>` hash. Preserve/reset its
+`generation` field to the authoritative value and remove stale owner/operation
+fields only after proving their holders cannot resume. Restart writers using
+fresh instance state. Never clear registrations merely because they are old.
+
+Roll out admission tracking to **all** stack/worker processes and drain older
+versions before enabling any maintenance caller. The barrier API alone does not
+fix the migration cutover race.
+
+## Tests
+
+```sh
+go test -race -short ./pkg/storagebarrier
+COZY_TEST_REDIS_URL=redis://localhost:6379/0 go test -race ./pkg/storagebarrier
+```
+
+The Redis tests use two independent clients, create uniquely named test keys,
+and remove only those keys. They cover admission/cutover races, nested uploads,
+cancelled draining, stale generations, lost ownership, and Redis errors.

--- a/pkg/storagebarrier/barrier.go
+++ b/pkg/storagebarrier/barrier.go
@@ -1,0 +1,265 @@
+// Package storagebarrier coordinates instance storage operations with migration.
+package storagebarrier
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/utils"
+	"github.com/redis/go-redis/v9"
+)
+
+var (
+	ErrBusy  = errors.New("storage migration in progress; retry later")
+	ErrStale = errors.New("storage backend changed; reload the instance and retry")
+	ErrLost  = errors.New("storage barrier state lost; manual recovery required")
+)
+
+// ponytail: permits deliberately do not expire. A crashed writer requires
+// operator recovery; automatic recovery needs storage-level fencing first.
+const script = `
+local action, token, generation = ARGV[1], ARGV[2], ARGV[3]
+if action == 'enter' or action == 'close' then
+  redis.call('hsetnx', KEYS[1], 'generation', generation)
+  if redis.call('hget', KEYS[1], 'generation') ~= generation then return -2 end
+  if redis.call('hexists', KEYS[1], 'owner') == 1 then return -1 end
+  if action == 'enter' then redis.call('hset', KEYS[1], token, '1')
+  else redis.call('hset', KEYS[1], 'owner', token) end
+  return 0
+end
+if action == 'leave' then
+  if redis.call('hdel', KEYS[1], token) ~= 1 then return -3 end
+  return 0
+end
+if redis.call('hget', KEYS[1], 'owner') ~= token then return -3 end
+if action == 'check' then return redis.call('hlen', KEYS[1]) - 2 end
+if action == 'open' then
+  local current = redis.call('hget', KEYS[1], 'generation')
+  if #generation < #current or (#generation == #current and generation < current) then return -2 end
+  if redis.call('hlen', KEYS[1]) ~= 2 then return -1 end
+  redis.call('hset', KEYS[1], 'generation', generation)
+  redis.call('hdel', KEYS[1], 'owner')
+  return 0
+end
+if action == 'cancel' then
+  redis.call('hdel', KEYS[1], 'owner')
+  return 0
+end
+return -3`
+
+type state struct {
+	generation int64
+	owner      string
+	readers    map[string]bool
+}
+
+// Service uses the configured lock Redis, or memory in a single-process stack.
+type Service struct {
+	client redis.UniversalClient
+	mu     sync.Mutex
+	states map[string]*state
+}
+
+func New(client redis.UniversalClient) *Service {
+	return &Service{client: client, states: make(map[string]*state)}
+}
+
+func (s *Service) operation(ctx context.Context, key, action, token string, generation int64) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if s.client != nil {
+		n, err := s.client.Eval(ctx, script, []string{"storage-barrier:" + key}, action, token, strconv.FormatInt(generation, 10)).Int64()
+		if err != nil {
+			return 0, fmt.Errorf("storage barrier: %w", err)
+		}
+		switch n {
+		case -1:
+			return 0, ErrBusy
+		case -2:
+			return 0, ErrStale
+		case -3:
+			return 0, ErrLost
+		}
+		return n, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	st := s.states[key]
+	if st == nil {
+		if action != "enter" && action != "close" {
+			return 0, ErrLost
+		}
+		st = &state{generation: generation, readers: make(map[string]bool)}
+		s.states[key] = st
+	}
+	switch action {
+	case "enter", "close":
+		if st.generation != generation {
+			return 0, ErrStale
+		}
+		if st.owner != "" {
+			return 0, ErrBusy
+		}
+		if action == "enter" {
+			st.readers[token] = true
+		} else {
+			st.owner = token
+		}
+	case "leave":
+		if !st.readers[token] {
+			return 0, ErrLost
+		}
+		delete(st.readers, token)
+	case "check", "open", "cancel":
+		if st.owner != token {
+			return 0, ErrLost
+		}
+		if action == "check" {
+			return int64(len(st.readers)), nil
+		}
+		if action == "cancel" {
+			st.owner = ""
+			return 0, nil
+		}
+		if generation < st.generation {
+			return 0, ErrStale
+		}
+		if len(st.readers) != 0 {
+			return 0, ErrBusy
+		}
+		st.generation, st.owner = generation, ""
+	default:
+		return 0, ErrLost
+	}
+	return 0, nil
+}
+
+type operation struct {
+	service    *Service
+	key, token string
+	generation int64
+	mu         sync.Mutex
+	refs       int
+}
+
+// Permit covers an operation through its last storage/index write. Forked
+// permits allow an already admitted request/job to finish during draining.
+type Permit struct {
+	op     *operation
+	once   sync.Once
+	err    error
+	closed bool // guarded by op.mu
+}
+
+// Enter admits an operation for a freshly loaded storage generation. A live
+// parent lets its nested operations finish after new admission is closed.
+func (s *Service) Enter(ctx context.Context, key string, generation int64, parent *Permit) (*Permit, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if key == "" || generation < 0 {
+		return nil, errors.New("storage barrier: invalid instance key or generation")
+	}
+	if parent != nil && parent.op.service == s && parent.op.key == key {
+		parent.op.mu.Lock()
+		if !parent.closed {
+			if parent.op.generation != generation {
+				parent.op.mu.Unlock()
+				return nil, ErrStale
+			}
+			parent.op.refs++
+			parent.op.mu.Unlock()
+			return &Permit{op: parent.op}, nil
+		}
+		parent.op.mu.Unlock()
+	}
+	token := "operation:" + utils.RandomString(32)
+	if _, err := s.operation(ctx, key, "enter", token, generation); err != nil {
+		return nil, err
+	}
+	return &Permit{op: &operation{service: s, key: key, token: token, generation: generation, refs: 1}}, nil
+}
+
+func (p *Permit) Close() error {
+	p.once.Do(func() {
+		p.op.mu.Lock()
+		defer p.op.mu.Unlock()
+		p.closed = true
+		p.op.refs--
+		if p.op.refs == 0 {
+			_, p.err = p.op.service.operation(context.Background(), p.op.key, "leave", p.op.token, 0)
+		}
+	})
+	return p.err
+}
+
+// Guard owns closed admission. It does not expire, including after a process
+// crash. Only this owner may reopen admission.
+type Guard struct {
+	service    *Service
+	key, token string
+}
+
+func (s *Service) Block(ctx context.Context, key string, generation int64) (*Guard, error) {
+	if key == "" || generation < 0 {
+		return nil, errors.New("storage barrier: invalid instance key or generation")
+	}
+	g := &Guard{service: s, key: key, token: utils.RandomString(32)}
+	if _, err := s.operation(ctx, key, "close", g.token, generation); err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+func (g *Guard) Wait(ctx context.Context) error {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		n, err := g.service.operation(ctx, g.key, "check", g.token, 0)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (g *Guard) Check(ctx context.Context) error {
+	n, err := g.service.operation(ctx, g.key, "check", g.token, 0)
+	if err != nil {
+		return err
+	}
+	if n != 0 {
+		return ErrBusy
+	}
+	return nil
+}
+
+// Open resumes admission only when every admitted operation has finished.
+// Persist the new backend and generation before calling it. A failed or
+// ambiguous backend update must leave the guard closed for operator recovery.
+func (g *Guard) Open(ctx context.Context, generation int64) error {
+	if generation < 0 {
+		return ErrStale
+	}
+	_, err := g.service.operation(ctx, g.key, "open", g.token, generation)
+	return err
+}
+
+// Cancel reopens admission without changing generation, even if operations are
+// still draining. Use only before modifying the backend or its contents.
+func (g *Guard) Cancel(ctx context.Context) error {
+	_, err := g.service.operation(ctx, g.key, "cancel", g.token, 0)
+	return err
+}

--- a/pkg/storagebarrier/barrier_test.go
+++ b/pkg/storagebarrier/barrier_test.go
@@ -1,0 +1,197 @@
+package storagebarrier
+
+import (
+	"context"
+	"math"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cozy/cozy-stack/pkg/utils"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryBarrier(t *testing.T) {
+	s := New(nil)
+	testBarrier(t, s, s)
+}
+
+func TestRedisBarrier(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Redis")
+	}
+	address := os.Getenv("COZY_TEST_REDIS_URL")
+	if address == "" {
+		address = "redis://localhost:6379/0"
+	}
+	opts, err := redis.ParseURL(address)
+	require.NoError(t, err)
+	one, two := redis.NewClient(opts), redis.NewClient(opts)
+	t.Cleanup(func() { _ = one.Close(); _ = two.Close() })
+	require.NoError(t, one.Ping(context.Background()).Err())
+	testBarrier(t, New(one), New(two))
+
+	t.Run("lost_owner_cannot_complete", func(t *testing.T) {
+		key := "barrier-test-" + utils.RandomString(16)
+		g, err := New(one).Block(context.Background(), key, 0)
+		require.NoError(t, err)
+		require.NoError(t, two.Del(context.Background(), "storage-barrier:"+key).Err())
+		require.ErrorIs(t, g.Check(context.Background()), ErrLost)
+		require.ErrorIs(t, g.Open(context.Background(), 1), ErrLost)
+		require.ErrorIs(t, g.Cancel(context.Background()), ErrLost)
+	})
+
+	t.Run("connection_failure_prevents_cutover", func(t *testing.T) {
+		client := redis.NewClient(opts)
+		key := "barrier-test-" + utils.RandomString(16)
+		t.Cleanup(func() { _ = one.Del(context.Background(), "storage-barrier:"+key).Err() })
+		g, err := New(client).Block(context.Background(), key, 0)
+		require.NoError(t, err)
+		require.NoError(t, client.Close())
+		require.Error(t, g.Check(context.Background()))
+		require.Error(t, g.Open(context.Background(), 1))
+		_, err = New(two).Enter(context.Background(), key, 0, nil)
+		require.ErrorIs(t, err, ErrBusy)
+	})
+}
+
+func testBarrier(t *testing.T, one, two *Service) {
+	t.Helper()
+	ctx := context.Background()
+	keyFor := func(t *testing.T) string {
+		key := "barrier-test-" + utils.RandomString(16)
+		if one.client != nil {
+			t.Cleanup(func() { require.NoError(t, one.client.Del(ctx, "storage-barrier:"+key).Err()) })
+		}
+		return key
+	}
+
+	t.Run("drain_upload_before_cutover", func(t *testing.T) {
+		key := keyFor(t)
+		upload, err := one.Enter(ctx, key, 0, nil)
+		require.NoError(t, err)
+		another, err := two.Enter(ctx, key, 0, nil)
+		require.NoError(t, err, "uploads must remain concurrent across processes")
+		g, err := two.Block(ctx, key, 0)
+		require.NoError(t, err)
+		_, err = one.Block(ctx, key, 0)
+		require.ErrorIs(t, err, ErrBusy)
+		_, err = one.Enter(ctx, key, 0, nil)
+		require.ErrorIs(t, err, ErrBusy)
+		require.ErrorIs(t, g.Check(ctx), ErrBusy)
+		require.ErrorIs(t, g.Open(ctx, 1), ErrBusy)
+
+		otherInstance, err := one.Enter(ctx, keyFor(t), 0, nil)
+		require.NoError(t, err)
+		require.NoError(t, otherInstance.Close())
+
+		waiting, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+		defer cancel()
+		require.ErrorIs(t, g.Wait(waiting), context.DeadlineExceeded)
+		require.NoError(t, upload.Close())
+		require.NoError(t, upload.Close(), "closing twice must not release another upload")
+		require.ErrorIs(t, g.Check(ctx), ErrBusy)
+		require.NoError(t, another.Close())
+		require.NoError(t, g.Wait(ctx))
+		require.NoError(t, g.Open(ctx, 1))
+		_, err = one.Enter(ctx, key, 0, nil)
+		require.ErrorIs(t, err, ErrStale)
+		fresh, err := one.Enter(ctx, key, 1, nil)
+		require.NoError(t, err)
+		require.NoError(t, fresh.Close())
+		require.ErrorIs(t, g.Cancel(ctx), ErrLost, "an old owner cannot reopen a newer barrier")
+	})
+
+	t.Run("admitted_job_finishes_nested_writes", func(t *testing.T) {
+		key := keyFor(t)
+		job, err := one.Enter(ctx, key, 0, nil)
+		require.NoError(t, err)
+		g, err := two.Block(ctx, key, 0)
+		require.NoError(t, err)
+		_, err = one.Enter(ctx, key, 1, job)
+		require.ErrorIs(t, err, ErrStale)
+		upload, err := one.Enter(ctx, key, 0, job)
+		require.NoError(t, err)
+		require.NoError(t, job.Close())
+		require.ErrorIs(t, g.Check(ctx), ErrBusy, "the nested upload still owns its permit")
+		_, err = one.Enter(ctx, key, 0, job)
+		require.ErrorIs(t, err, ErrBusy, "a closed parent must not admit more work")
+		require.NoError(t, upload.Close())
+		require.NoError(t, g.Wait(ctx))
+		require.NoError(t, g.Open(ctx, 0))
+	})
+
+	t.Run("generation_comparison_is_exact", func(t *testing.T) {
+		key := keyFor(t)
+		g, err := one.Block(ctx, key, math.MaxInt64)
+		require.NoError(t, err)
+		require.ErrorIs(t, g.Open(ctx, math.MaxInt64-1), ErrStale)
+		require.NoError(t, g.Cancel(ctx))
+	})
+
+	t.Run("cancel_drain_without_changing_backend", func(t *testing.T) {
+		key := keyFor(t)
+		p, err := one.Enter(ctx, key, 3, nil)
+		require.NoError(t, err)
+		g, err := two.Block(ctx, key, 3)
+		require.NoError(t, err)
+		require.NoError(t, g.Cancel(ctx))
+		next, err := two.Enter(ctx, key, 3, nil)
+		require.NoError(t, err)
+		require.NoError(t, next.Close())
+		require.NoError(t, p.Close())
+		g, err = one.Block(ctx, key, 3)
+		require.NoError(t, err)
+		require.ErrorIs(t, g.Open(ctx, 2), ErrStale, "generation cannot move backwards")
+		require.NoError(t, g.Open(ctx, 4))
+	})
+
+	t.Run("admission_racing_with_block", func(t *testing.T) {
+		key := keyFor(t)
+		start := make(chan struct{})
+		permits := make(chan *Permit, 16)
+		errs := make(chan error, 16)
+		var wg sync.WaitGroup
+		for range 16 {
+			wg.Go(func() {
+				<-start
+				p, err := one.Enter(ctx, key, 0, nil)
+				if err != nil {
+					errs <- err
+				} else {
+					permits <- p
+				}
+			})
+		}
+		close(start)
+		g, err := two.Block(ctx, key, 0)
+		require.NoError(t, err)
+		wg.Wait()
+		close(permits)
+		close(errs)
+		for err := range errs {
+			require.ErrorIs(t, err, ErrBusy)
+		}
+		for p := range permits {
+			require.NoError(t, p.Close())
+		}
+		require.NoError(t, g.Wait(ctx))
+		require.NoError(t, g.Open(ctx, 1))
+	})
+
+	t.Run("invalid_or_cancelled_admission", func(t *testing.T) {
+		key := keyFor(t)
+		_, err := one.Enter(ctx, "", 0, nil)
+		require.Error(t, err)
+		_, err = one.Block(ctx, key, -1)
+		require.Error(t, err)
+		cancelled, cancel := context.WithCancel(ctx)
+		cancel()
+		_, err = one.Enter(cancelled, key, 0, nil)
+		require.ErrorIs(t, err, context.Canceled)
+		_, err = one.Block(cancelled, key, 0)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}


### PR DESCRIPTION
## Summary

- Add a storage barrier with concurrent operation permits, draining, exclusive maintenance ownership, and generation checks.
- Cover memory and Redis behavior, admission races, nested operations, and coordination failures with race-tested regression tests.
- Document deployment prerequisites, non-expiring permits, and manual recovery requirements.
- Keep this as a foundation-only draft: HTTP, worker, VFS, and migration callers are not integrated yet.
- Validation: package tests passed against memory and Redis with the Go race detector; memory tests also passed 20 repeated runs.